### PR TITLE
Enable Prometheus endpoint in AM

### DIFF
--- a/forgecloud/default/README.md
+++ b/forgecloud/default/README.md
@@ -1,0 +1,29 @@
+# Default ForgeCloud Configuration Notes
+
+The following notes describe what modifications have been made to base AM/IDM/etc configurations.
+
+## AM 6.0
+
+Configuration is determined by comparing exported Amster files before a change is made in the UI and then after.
+
+### global/Monitoring.json
+
+- data.enabled = true
+
+### global/PrometheusReporter/prometheus.json
+
+- data.enabled = true
+- data.password = prometheus
+- data.password-encrypted = null
+
+### global/Realms/root.json
+
+- data.aliases = [ "userstore", "openam", "&{fqdn}" ]
+
+### global/Sites/site1.json
+
+- data.url = http://&{fqdn}/openam
+
+## IDM 6.0
+
+TODO :)

--- a/forgecloud/default/README.md
+++ b/forgecloud/default/README.md
@@ -14,7 +14,7 @@ Configuration is determined by comparing exported Amster files before a change i
 
 - data.enabled = true
 - data.password = prometheus
-- data.password-encrypted = null
+- **remove** data.password-encrypted
 
 ### global/Realms/root.json
 

--- a/forgecloud/default/am/global/Monitoring.json
+++ b/forgecloud/default/am/global/Monitoring.json
@@ -8,7 +8,7 @@
   },
   "data" : {
     "_id" : "",
-    "enabled" : false,
+    "enabled" : true,
     "httpEnabled" : false,
     "snmpEnabled" : false,
     "authfilePath" : "%BASE_DIR%/%SERVER_URI%/openam_mon_auth",

--- a/forgecloud/default/am/global/PrometheusReporter/prometheus.json
+++ b/forgecloud/default/am/global/PrometheusReporter/prometheus.json
@@ -8,9 +8,9 @@
   },
   "data" : {
     "_id" : "prometheus",
-    "password" : null,
-    "password-encrypted" : "AAAAA0FFUwIQ+JLJ69WyiBkQ2ddpVElCGRYm8/YKRYNU7+4YonRbPn4vFXzKSa3fMw==",
-    "enabled" : false,
+    "password" : "prometheus",
+    "password-encrypted" : null,
+    "enabled" : true,
     "username" : "prometheus",
     "_type" : {
       "_id" : "prometheus",

--- a/forgecloud/default/am/global/PrometheusReporter/prometheus.json
+++ b/forgecloud/default/am/global/PrometheusReporter/prometheus.json
@@ -9,7 +9,6 @@
   "data" : {
     "_id" : "prometheus",
     "password" : "prometheus",
-    "password-encrypted" : null,
     "enabled" : true,
     "username" : "prometheus",
     "_type" : {


### PR DESCRIPTION
Enable Prometheus endpoint in AM. The Prometheus endpoint is already enabled by default for IDM.

AM:
```
curl -v --request GET --user prometheus:prometheus \
    "http://openam:8080/openam/json/metrics/prometheus"
````

IDM:
```
curl \
--header "X-OpenIDM-Username: prometheus" \
--header "X-OpenIDM-Password: prometheus" \
--request GET \
'http://openidm:8080/openidm/metrics/prometheus?_fields=text&_mimeType=text%2Fplain%3Bversion%3D0.0.4'
```