### PR TITLE
FRAAS-349 Enable monitoring by default in each product

### DIFF
--- a/forgecloud/default/am/global/Monitoring.json
+++ b/forgecloud/default/am/global/Monitoring.json
@@ -8,7 +8,7 @@
    },
    "data" : {
      "_id" : "",
-    "enabled" : false,
+    "enabled" : true,
      "httpEnabled" : false,
      "snmpEnabled" : false,
      "authfilePath" : "%BASE_DIR%/%SERVER_URI%/openam_mon_auth",

--- a/forgecloud/default/am/global/PrometheusReporter/prometheus.json
+++ b/forgecloud/default/am/global/PrometheusReporter/prometheus.json
@@ -10,7 +10,7 @@
      "_id" : "prometheus",
     "password" : "&{prometheus.password}",
     "authenticationType" : "BASIC",
-    "enabled" : false,
+    "enabled" : true,
      "username" : "prometheus",
      "_type" : {
        "_id" : "prometheus",

--- a/forgecloud/default/idm/conf/metrics.json
+++ b/forgecloud/default/idm/conf/metrics.json
@@ -1,4 +1,4 @@
 {
-    "enabled" : false,
+    "enabled" : true,
     "prometheusRole" : "&{openidm.prometheus.role}"
 }


### PR DESCRIPTION
This change enables monitoring by default on AM and IDM. Note that monitoring is already enabled by default on DS. 