### PR TITLE
FRAAS-815 Update Identity Stack to include new AM CORS functionality

### DIFF
--- a/forgecloud/default/am/am.Dockerfile
+++ b/forgecloud/default/am/am.Dockerfile
@@ -1,1 +1,1 @@
-FROM gcr.io/forgerock-io/am:7.0.0-1f4295b5ae
+FROM gcr.io/forgerock-io/am/pit1:7.0.0-ac226be52e

--- a/forgecloud/default/am/amster.Dockerfile
+++ b/forgecloud/default/am/amster.Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/forgerock-io/amster:7.0.0-1f4295b5ae
+FROM gcr.io/forgerock-io/amster/pit1:7.0.0-ac226be52e
 COPY global /opt/amster/config/global
 COPY realms /opt/amster/config/realms

--- a/forgecloud/default/ds/Dockerfile
+++ b/forgecloud/default/ds/Dockerfile
@@ -1,2 +1,2 @@
-FROM gcr.io/forgerock-io/ds/pit1:7.0.0-8ad7f77
+FROM gcr.io/forgerock-io/ds/docker-build:7.0.0-150adc4
 COPY schema/ /opt/opendj/db/schema/

--- a/forgecloud/default/ds/Dockerfile
+++ b/forgecloud/default/ds/Dockerfile
@@ -1,2 +1,2 @@
-FROM gcr.io/forgerock-io/ds:7.0.0-98c91bd
+FROM gcr.io/forgerock-io/ds/pit1:7.0.0-8ad7f77
 COPY schema/ /opt/opendj/db/schema/

--- a/forgecloud/default/idm/Dockerfile
+++ b/forgecloud/default/idm/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/forgerock-io/idm:7.0.0-295e721
+FROM gcr.io/forgerock-io/idm/pit1:7.0.0-eb9db00
 COPY conf /opt/openidm/conf
 COPY script /opt/openidm/script


### PR DESCRIPTION
This PR copies the set of Docker image references from [forgeops|https://stash.forgerock.org/projects/CLOUD/repos/forgeops/browse] to the FROM statements of the Docker images defined in [forgeops-init|https://github.com/ForgeCloud/forgeops-init].

forgeops commit: [d0d7d0d5a25d4439a17a30cd8beceb4cd827facd](https://stash.forgerock.org/projects/CLOUD/repos/forgeops/commits/d0d7d0d5a25d4439a17a30cd8beceb4cd827facd)
```
    forgeops/helm/openam/values.yaml     -->    forgeops-init/forgecloud/default/am/am.Dockerfile
    forgeops/helm/amster/values.yaml     -->    forgeops-init/forgecloud/default/am/amster.Dockerfile
    forgeops/helm/ds/values.yaml         -->    forgeops-init/forgecloud/default/ds/Dockerfile
    forgeops/helm/openidm/values.yaml    -->    forgeops-init/forgecloud/default/idm/Dockerfile
```

---

The Docker images built by running the Codefresh pipelines from this repo once this PR is merged will be used in the saas monorepo:

```
    forgeops-init/forgecloud/default/am/am.Dockerfile       -->   saas/services/go/org-engine/configs/openam.yaml
    forgeops-init/forgecloud/default/am/amster.Dockerfile   -->   saas/services/go/org-engine/configs/amster.yaml
    forgeops-init/forgecloud/default/ds/Dockerfile          -->   saas/services/go/org-engine/configs/ctsstore.yaml
    forgeops-init/forgecloud/default/ds/Dockerfile          -->   saas/services/go/org-engine/configs/userstore.yaml
    forgeops-init/forgecloud/default/idm/Dockerfile         -->   saas/services/go/org-engine/configs/openidm.yaml
```

The saas monorepo customer-environment.steps.yml step which clones the forgeops Git repo will also be updated to checkout `d0d7d0d5a25d4439a17a30cd8beceb4cd827facd` (same commit of forgeops as was used as reference for the Docker image tag references used here).

```
    d0d7d0d5a25d4439a17a30cd8beceb4cd827facd   -->   saas/deploy/codefresh/customer-environment.steps.yml
```