### PR TITLE
FRAAS-1048 Rename labels to follow Docker guidelines

### DIFF
--- a/forgecloud/default/am/am.Dockerfile
+++ b/forgecloud/default/am/am.Dockerfile
@@ -3,5 +3,5 @@
 FROM gcr.io/forgerock-io/am/pit1:7.0.0-481bd1a8e5
 # WARNING: FORGEOPS_COMMIT_SHA and AM_DOCKER_TAG labels should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL FORGEOPS_COMMIT_SHA=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
-    AM_DOCKER_TAG=7.0.0-481bd1a8e5
+LABEL com.forgerock.forgeops.hash=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
+    com.forgerock.am.tag=7.0.0-481bd1a8e5

--- a/forgecloud/default/am/amster.Dockerfile
+++ b/forgecloud/default/am/amster.Dockerfile
@@ -3,7 +3,7 @@
 FROM gcr.io/forgerock-io/amster/pit1:7.0.0-481bd1a8e5
 # WARNING: FORGEOPS_COMMIT_SHA and AMSTER_DOCKER_TAG labels should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL FORGEOPS_COMMIT_SHA=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
-    AMSTER_DOCKER_TAG=7.0.0-481bd1a8e5
+LABEL com.forgerock.forgeops.hash=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
+    com.forgerock.amster.tag=7.0.0-481bd1a8e5
 COPY global /opt/amster/config/global
 COPY realms /opt/amster/config/realms

--- a/forgecloud/default/ds/Dockerfile
+++ b/forgecloud/default/ds/Dockerfile
@@ -3,6 +3,6 @@
 FROM gcr.io/forgerock-io/ds/pit1:7.0.0-179536e
 # WARNING: FORGEOPS_COMMIT_SHA and DS_DOCKER_TAG labels should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL FORGEOPS_COMMIT_SHA=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
-    DS_DOCKER_TAG=7.0.0-179536e
+LABEL com.forgerock.forgeops.hash=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
+    com.forgerock.ds.tag=7.0.0-179536e
 COPY schema/ /opt/opendj/db/schema/

--- a/forgecloud/default/idm/Dockerfile
+++ b/forgecloud/default/idm/Dockerfile
@@ -3,7 +3,7 @@
 FROM gcr.io/forgerock-io/idm/pit1:7.0.0-4da29dc
 # WARNING: FORGEOPS_COMMIT_SHA and IDM_DOCKER_TAG labels should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL FORGEOPS_COMMIT_SHA=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
-    IDM_DOCKER_TAG=7.0.0-4da29dc
+LABEL com.forgerock.forgeops.hash=c6e38bcbb96efe64ed32ab24f167e9fa3c476719 \
+    com.forgerock.idm.tag=7.0.0-4da29dc
 COPY conf /opt/openidm/conf
 COPY script /opt/openidm/script

--- a/scripts/upgrade_identity_stack.sh
+++ b/scripts/upgrade_identity_stack.sh
@@ -94,6 +94,9 @@ function update_dockerfile() {
     DOCKER_REPO=$3
     DOCKER_TAG=$4
 
+    FORGEOPS_COMMIT_SHA_LABEL=com.forgerock.forgeops.hash
+    PRODUCT_DOCKER_TAG_LABEL=com.forgerock.${PRODUCT}.tag
+
     FROM_LINE=$(grep -nr "FROM " ${DOCKER_FILE} | cut -d : -f 2)
     LENGTH=$(wc -l < ${DOCKER_FILE})
 
@@ -103,15 +106,15 @@ function update_dockerfile() {
     sed -i.bak -E "s;FROM .*;FROM ${DOCKER_REPO}:${DOCKER_TAG};" ${TEMP_DOCKER_FILE}
     # NB. ending the first label line with backslash so that we define both labels in a single Docker layer
     #     we need to double-escape the backslash though (once for bash, and once for sed) so end up with \\\\
-    sed -i.bak -E "s/LABEL FORGEOPS_COMMIT_SHA=.*/LABEL FORGEOPS_COMMIT_SHA=${FORGEOPS_COMMIT_SHA} \\\\/" ${TEMP_DOCKER_FILE}
-    sed -i.bak -E "s/    ${PRODUCT}_DOCKER_TAG=.*/    ${PRODUCT}_DOCKER_TAG=.${DOCKER_TAG}/" ${TEMP_DOCKER_FILE}
+    sed -i.bak -E "s/LABEL ${FORGEOPS_COMMIT_SHA_LABEL}=.*/LABEL ${FORGEOPS_COMMIT_SHA_LABEL}=${FORGEOPS_COMMIT_SHA} \\\\/" ${TEMP_DOCKER_FILE}
+    sed -i.bak -E "s/    ${PRODUCT_DOCKER_TAG_LABEL}=.*/    ${PRODUCT_DOCKER_TAG_LABEL}=.${DOCKER_TAG}/" ${TEMP_DOCKER_FILE}
     mv /tmp/tmp.Dockerfile ${DOCKER_FILE}
 }
 
-update_dockerfile "AM" ${GIT_REPO_ROOT}/forgecloud/default/am/am.Dockerfile ${AM_DOCKER_REPO} ${AM_DOCKER_TAG}
-update_dockerfile "AMSTER" ${GIT_REPO_ROOT}/forgecloud/default/am/amster.Dockerfile ${AMSTER_DOCKER_REPO} ${AMSTER_DOCKER_TAG}
-update_dockerfile "DS" ${GIT_REPO_ROOT}/forgecloud/default/ds/Dockerfile ${DS_DOCKER_REPO} ${DS_DOCKER_TAG}
-update_dockerfile "IDM" ${GIT_REPO_ROOT}/forgecloud/default/idm/Dockerfile ${IDM_DOCKER_REPO} ${IDM_DOCKER_TAG}
+update_dockerfile "am" ${GIT_REPO_ROOT}/forgecloud/default/am/am.Dockerfile ${AM_DOCKER_REPO} ${AM_DOCKER_TAG}
+update_dockerfile "amster" ${GIT_REPO_ROOT}/forgecloud/default/am/amster.Dockerfile ${AMSTER_DOCKER_REPO} ${AMSTER_DOCKER_TAG}
+update_dockerfile "ds" ${GIT_REPO_ROOT}/forgecloud/default/ds/Dockerfile ${DS_DOCKER_REPO} ${DS_DOCKER_TAG}
+update_dockerfile "idm" ${GIT_REPO_ROOT}/forgecloud/default/idm/Dockerfile ${IDM_DOCKER_REPO} ${IDM_DOCKER_TAG}
 
 println "done"
 


### PR DESCRIPTION
Updates the keys used for custom labels to follow [Docker guidelines](https://docs.docker.com/config/labels-custom-metadata/)