### PR TITLE
FRAAS-1318 Upgrade to latest PIT 2 tested Identity Stack

### DIFF
--- a/.forgeops
+++ b/.forgeops
@@ -1,7 +1,7 @@
 ###
-# Generated at 2019-08-19T20:47:05Z by forgeops-init/scripts/upgrade_identity_stack.sh
+# Generated at 2019-09-17T09:36:53Z by forgeops-init/scripts/upgrade_identity_stack.sh
 #
 # This file records the forgeops commit from which all the Identity Stack Docker image references were taken.
 # This reference is consumed by the script saas/devtools/upgrade_identity_stack.sh
 
-FORGEOPS_COMMIT_SHA=c1254a81ecf440bf2852316c69598f1055f068e3
+FORGEOPS_COMMIT_SHA=37865f90dfe13c1408558f239e24b41efb71ec13

--- a/forgecloud/default/am/am.Dockerfile
+++ b/forgecloud/default/am/am.Dockerfile
@@ -1,9 +1,9 @@
 # WARNING: Base image reference should not be set manually.
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-FROM gcr.io/forgerock-io/am/pit1:7.0.0-4eb16a442b
+FROM gcr.io/forgerock-io/am:7.0.0-f0e19e1456c8aa08ef6b12907765ad3ace6c05bc
 # WARNING: AM_DOCKER_TAG label should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL com.forgerock.am.tag=7.0.0-4eb16a442b
+LABEL com.forgerock.am.tag=7.0.0-f0e19e1456c8aa08ef6b12907765ad3ace6c05bc
 
 ENV LOGBACK=https://repo.maven.apache.org/maven2/ch/qos/logback
 

--- a/forgecloud/default/am/amster.Dockerfile
+++ b/forgecloud/default/am/amster.Dockerfile
@@ -1,8 +1,8 @@
 # WARNING: Base image reference should not be set manually.
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-FROM gcr.io/forgerock-io/amster/pit1:7.0.0-4eb16a442b
+FROM gcr.io/forgerock-io/amster:7.0.0-f0e19e1456c8aa08ef6b12907765ad3ace6c05bc
 # WARNING: AMSTER_DOCKER_TAG label should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL com.forgerock.amster.tag=7.0.0-4eb16a442b
+LABEL com.forgerock.amster.tag=7.0.0-f0e19e1456c8aa08ef6b12907765ad3ace6c05bc
 COPY global /opt/amster/config/global
 COPY realms /opt/amster/config/realms

--- a/forgecloud/default/ds/Dockerfile
+++ b/forgecloud/default/ds/Dockerfile
@@ -1,7 +1,7 @@
 # WARNING: Base image reference should not be set manually.
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-FROM gcr.io/forgerock-io/ds/pit1:7.0.0-dde97a1
+FROM gcr.io/forgerock-io/ds:7.0.0-1fb511561463754f900ae7f19d42cc6e3ec845ec
 # WARNING: DS_DOCKER_TAG label should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL com.forgerock.ds.tag=7.0.0-dde97a1
+LABEL com.forgerock.ds.tag=7.0.0-1fb511561463754f900ae7f19d42cc6e3ec845ec
 COPY schema/ /opt/opendj/db/schema/

--- a/forgecloud/default/idm/Dockerfile
+++ b/forgecloud/default/idm/Dockerfile
@@ -1,8 +1,8 @@
 # WARNING: Base image reference should not be set manually.
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-FROM gcr.io/forgerock-io/idm/pit1:7.0.0-576f4b6d46617db6dfe00d00a0f28dc9db5b6123
+FROM gcr.io/forgerock-io/idm:7.0.0-2cdee7ccd81a2c6f09ab4363843cd1bf4d2ab254
 # WARNING: IDM_DOCKER_TAG label should not be set manually
 # To "upgrade" to a later release of the Identity Stack, use the script: /scripts/upgrade_identity_stack.sh
-LABEL com.forgerock.idm.tag=7.0.0-576f4b6d46617db6dfe00d00a0f28dc9db5b6123
+LABEL com.forgerock.idm.tag=7.0.0-2cdee7ccd81a2c6f09ab4363843cd1bf4d2ab254
 COPY conf /opt/openidm/conf
 COPY script /opt/openidm/script

--- a/forgecloud/default/idm/base/README.md
+++ b/forgecloud/default/idm/base/README.md
@@ -1,0 +1,5 @@
+# Default Config
+
+This directory contains the default config found in the IDM Docker image.
+
+This content was extracted using `scripts/export_default_idm_base_config.sh`

--- a/forgecloud/default/idm/base/conf/audit.json
+++ b/forgecloud/default/idm/base/conf/audit.json
@@ -1,0 +1,94 @@
+{
+    "auditServiceConfig" : {
+        "handlerForQueries" : "json",
+        "availableAuditEventHandlers" : [
+            "org.forgerock.audit.handlers.csv.CsvAuditEventHandler",
+            "org.forgerock.audit.handlers.elasticsearch.ElasticsearchAuditEventHandler",
+            "org.forgerock.audit.handlers.jms.JmsAuditEventHandler",
+            "org.forgerock.audit.handlers.json.JsonAuditEventHandler",
+            "org.forgerock.audit.handlers.json.stdout.JsonStdoutAuditEventHandler",
+            "org.forgerock.openidm.audit.impl.RepositoryAuditEventHandler",
+            "org.forgerock.openidm.audit.impl.RouterAuditEventHandler",
+            "org.forgerock.audit.handlers.splunk.SplunkAuditEventHandler",
+            "org.forgerock.audit.handlers.syslog.SyslogAuditEventHandler"
+        ],
+        "filterPolicies" : {
+            "field" : {
+                "excludeIf" : [ ],
+                "includeIf" : [ ]
+            }
+        },
+        "caseInsensitiveFields" : [
+            "/access/http/request/headers",
+            "/access/http/response/headers"
+        ]
+    },
+    "eventHandlers" : [
+        {
+            "class" : "org.forgerock.audit.handlers.json.JsonAuditEventHandler",
+            "config" : {
+                "name" : "json",
+                "logDirectory" : "&{idm.data.dir}/audit",
+                "buffering" : {
+                    "maxSize" : 100000,
+                    "writeInterval" : "100 millis"
+                },
+                "topics" : [
+                    "access",
+                    "activity",
+                    "recon",
+                    "sync",
+                    "authentication",
+                    "config"
+                ]
+            }
+        },
+        {
+            "class": "org.forgerock.openidm.audit.impl.RepositoryAuditEventHandler",
+            "config": {
+                "name": "repo",
+                "enabled": false,
+                "topics": [
+                    "access",
+                    "activity",
+                    "recon",
+                    "sync",
+                    "authentication",
+                    "config"
+                ]
+            }
+        }
+    ],
+    "eventTopics" : {
+        "config" : {
+            "filter" : {
+                "actions" : [
+                    "create",
+                    "update",
+                    "delete",
+                    "patch",
+                    "action"
+                ]
+            }
+        },
+        "activity" : {
+            "filter" : {
+                "actions" : [
+                    "create",
+                    "update",
+                    "delete",
+                    "patch",
+                    "action"
+                ]
+            },
+            "watchedFields" : [ ],
+            "passwordFields" : [
+                "password"
+            ]
+        }
+    },
+    "exceptionFormatter" : {
+        "type" : "text/javascript",
+        "file" : "bin/defaults/script/audit/stacktraceFormatter.js"
+    }
+}

--- a/forgecloud/default/idm/base/conf/auth.profile.json
+++ b/forgecloud/default/idm/base/conf/auth.profile.json
@@ -1,0 +1,8 @@
+{
+  "profileEnhancementProcesses": [
+    "selfservice/termsAndConditions",
+    "selfservice/kbaUpdate",
+    "selfservice/profile"
+  ],
+  "authorizationRole": "internal/role/openidm-authorized"
+}

--- a/forgecloud/default/idm/base/conf/authentication.json
+++ b/forgecloud/default/idm/base/conf/authentication.json
@@ -1,0 +1,89 @@
+ {
+    "serverAuthContext" : {
+        "sessionModule" : {
+            "name" : "JWT_SESSION",
+            "properties" : {
+                "maxTokenLifeMinutes" : 120,
+                "tokenIdleTimeMinutes" : 30,
+                "sessionOnly" : true,
+                "isHttpOnly" : true,
+                "enableDynamicRoles" : false
+            }
+        },
+        "authModules" : [
+            {
+                "name" : "STATIC_USER",
+                "properties" : {
+                    "queryOnResource" : "internal/user",
+                    "username" : "anonymous",
+                    "password" : "anonymous",
+                    "defaultUserRoles" : [
+                        "internal/role/openidm-reg"
+                    ]
+                },
+                "enabled" : true
+            },
+            {
+                "name" : "MANAGED_USER",
+                "properties" : {
+                    "augmentSecurityContext": {
+                        "type" : "text/javascript",
+                        "source" : "require('auth/customAuthz').setProtectedAttributes(security)"
+                    },
+                    "queryId" : "credential-query",
+                    "queryOnResource" : "managed/user",
+                    "propertyMapping" : {
+                        "authenticationId" : "username",
+                        "userCredential" : "password",
+                        "userRoles" : "authzRoles"
+                    },
+                    "defaultUserRoles" : [ ]
+                },
+                "enabled" : true
+            },
+            {
+                "name" : "INTERNAL_USER",
+                "properties" : {
+                    "queryId" : "credential-internaluser-query",
+                    "queryOnResource" : "internal/user",
+                    "propertyMapping" : {
+                        "authenticationId" : "username",
+                        "userCredential" : "password",
+                        "userRoles" : "authzRoles"
+                    },
+                    "defaultUserRoles" : [ ]
+                },
+                "enabled" : true
+            },
+            {
+                "name" : "SOCIAL_PROVIDERS",
+                "properties" : {
+                    "defaultUserRoles" : [
+                        "internal/role/openidm-authorized"
+                    ],
+                    "augmentSecurityContext" : {
+                        "type" : "text/javascript",
+                        "globals" : { },
+                        "file" : "auth/populateAsManagedUserFromRelationship.js"
+                    },
+                    "propertyMapping" : {
+                        "userRoles" : "authzRoles"
+                    }
+                },
+                "enabled" : true
+            },
+            {
+                "name" : "STATIC_USER",
+                "properties" : {
+                    "queryOnResource" : "internal/user",
+                    "username" : "&{openidm.prometheus.username}",
+                    "password" : "&{openidm.prometheus.password}",
+                    "defaultUserRoles" : [
+                        "&{openidm.prometheus.role}"
+                    ]
+                },
+                "enabled" : true
+            }
+        ]
+    }
+}

--- a/forgecloud/default/idm/base/conf/cluster.json
+++ b/forgecloud/default/idm/base/conf/cluster.json
@@ -1,0 +1,8 @@
+{
+    "instanceId" : "&{openidm.node.id}",
+    "instanceTimeout" : 30000,
+    "instanceRecoveryTimeout" : 30000,
+    "instanceCheckInInterval" : 5000,
+    "instanceCheckInOffset" : 0,
+    "enabled" : true
+}

--- a/forgecloud/default/idm/base/conf/config.properties
+++ b/forgecloud/default/idm/base/conf/config.properties
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
+# Framework config properties.
+#
+
+# To override the packages the framework exports by default from the
+# class path, set this variable.
+#org.osgi.framework.system.packages=
+
+# To append packages to the default set of exported system packages,
+# set this value.
+org.osgi.framework.system.packages.extra=sun.misc,org.forgerock.openidm.launcher,sun.security.pkcs11,com.sun.management.comm,com.sun.management.snmp,com.sun.management.snmp.agent,com.sun.nio.file
+
+# The following property makes specified packages from the class path
+# available to all bundles. You should avoid using this property.
+org.osgi.framework.bootdelegation=sun.*,com.sun.*,apple.*,com.apple.*,javax.net.ssl,javax.xml.*,jdk.internal.*
+
+# Felix tries to guess when to implicitly boot delegate in certain
+# situations to ease integration without outside code. This feature
+# is enabled by default, uncomment the following line to disable it.
+#felix.bootdelegation.implicit=false
+
+# The following property explicitly specifies the location of the bundle
+# cache, which defaults to "felix-cache" in the current working directory.
+# If this value is not absolute, then the felix.cache.rootdir controls
+# how the absolute location is calculated. (See buildNext property)
+#org.osgi.framework.storage=&{felix.cache.rootdir|&{user.dir}}/felix-cache
+
+# The following property controls whether the bundle cache is flushed
+# the first time the framework is initialized. Possible values are
+# "none" and "onFirstInit"; the default is "none".
+org.osgi.framework.storage.clean=onFirstInit
+
+# framework.service.urlhandlers - specifies whether or not to activate the URL Handlers
+# service for the framework newBuilder; the default value is "true",
+# which results in the URL.setURLStreamHandlerFactory() and
+# URLConnection.setContentHandlerFactory() being called.
+
+# felix.log.level - specifies an integer String whose value indicates the degree of
+# logging reported by the framework; the default value is "1" and "0" turns off logging completely,
+# otherwise log levels match those specified in the OSGi Log Service
+# (i.e., 1 = error, 2 = warning, 3 = information, and 4 = debug).
+# We log osgi entries via a log listener, and hence default the internal logging service logging to off
+felix.log.level=0
+
+# Sets the initial start level of the framework upon startup.
+org.osgi.framework.startlevel.beginning=12
+
+# Sets the start level of newly installed bundles.
+felix.startlevel.bundle=10
+
+# Felix installs a stream and content handler factories by default,
+# uncomment the following line to not install them.
+#felix.service.urlhandlers=false
+
+# The launcher registers a shutdown hook to cleanly stop the framework
+# by default, uncomment the following line to disable it.
+#felix.shutdown.hook=false
+
+# The name of the PersistenceManager to be used by the framework
+# when persisting component configurations.
+felix.cm.pm=repo
+
+#
+# Bundle config properties.
+#
+
+obr.repository.url=http://felix.apache.org/obr/releases.xml
+
+# Configures the web embedded Web server via the following file
+org.ops4j.pax.web.config.file=&{idm.instance.dir}/conf/jetty.xml
+
+# Enable pax web http/https services to enable jetty
+org.osgi.service.http.enabled=true
+org.osgi.service.http.secure.enabled=true
+
+# To stop writes to configuration files, set this property to false; suitable for read-only installations.
+#felix.fileinstall.enableConfigSave=false
+
+# Add the windows server 2012 osname alias until https://issues.apache.org/jira/browse/FELIX-5184 is fixed.
+felix.native.osname.alias.windowsserver2012=windows server 2012,win32

--- a/forgecloud/default/idm/base/conf/emailTemplate-forgottenUsername.json
+++ b/forgecloud/default/idm/base/conf/emailTemplate-forgottenUsername.json
@@ -1,0 +1,14 @@
+{
+    "enabled" : true,
+    "from" : "",
+    "subject" : {
+        "en" :  "Account Information - username",
+        "fr" : "Informations sur le compte - nom d'utilisateur"
+    },
+    "message" : {
+        "en" : "<html><body>{{#if object.userName}}<p>Your username is '{{object.userName}}'.</p>{{else}}If you received this email in error, please disregard.{{/if}}</body></html>",
+        "fr" : "<html><body>{{#if object.userName}}<p>Votre nom d'utilisateur est '{{object.userName}}'.</p>{{else}}Si vous avez reçu cet e-mail par erreur, veuillez ne pas en tenir compte.{{/if}}</body></html>"
+    },
+    "defaultLocale" : "en",
+    "mimeType" : "text/html"
+}

--- a/forgecloud/default/idm/base/conf/emailTemplate-welcome.json
+++ b/forgecloud/default/idm/base/conf/emailTemplate-welcome.json
@@ -1,0 +1,14 @@
+{
+    "enabled" : true,
+    "from" : "",
+    "subject" : {
+        "en" : "Your account has been created",
+        "fr" : "Votre compte vient d’être créé !"
+    },
+    "message" : {
+        "en" : "<html><body><p>Welcome to OpenIDM. Your username is '{{object.userName}}'.</p></body></html>",
+        "fr" : "<html><body><p>Bienvenue sur OpenIDM. Votre nom d'utilisateur est '{{object.userName}}'.</p></body></html>"
+    },
+    "defaultLocale" : "en",
+    "mimeType" : "text/html"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-getavailableuserstoassign.json
+++ b/forgecloud/default/idm/base/conf/endpoint-getavailableuserstoassign.json
@@ -1,0 +1,4 @@
+{
+    "type" : "text/javascript",
+    "file" : "workflow/getavailableuserstoassign.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-getprocessesforuser.json
+++ b/forgecloud/default/idm/base/conf/endpoint-getprocessesforuser.json
@@ -1,0 +1,4 @@
+{
+    "type" : "text/javascript",
+    "file" : "workflow/getprocessesforuser.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-gettasksview.json
+++ b/forgecloud/default/idm/base/conf/endpoint-gettasksview.json
@@ -1,0 +1,4 @@
+{
+    "type" : "text/javascript",
+    "file" : "workflow/gettasksview.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-linkedView.json
+++ b/forgecloud/default/idm/base/conf/endpoint-linkedView.json
@@ -1,0 +1,5 @@
+{
+    "context" : "endpoint/linkedView/*",
+    "type" : "text/javascript",
+    "source" : "require('linkedView').fetch(request.resourcePath);"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-mappingDetails.json
+++ b/forgecloud/default/idm/base/conf/endpoint-mappingDetails.json
@@ -1,0 +1,5 @@
+{
+    "type" : "text/javascript",
+    "context" : "endpoint/mappingDetails",
+    "file" : "mappingDetails.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-oauthproxy.json
+++ b/forgecloud/default/idm/base/conf/endpoint-oauthproxy.json
@@ -1,0 +1,5 @@
+{
+    "context" : "endpoint/oauthproxy",
+    "type" : "text/javascript",
+    "file" : "oauthProxy.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-reconResults.json
+++ b/forgecloud/default/idm/base/conf/endpoint-reconResults.json
@@ -1,0 +1,5 @@
+{
+    "type" : "text/javascript",
+    "context" : "endpoint/reconResults",
+    "file" : "reconResults.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-removeRepoPathFromRelationships.json
+++ b/forgecloud/default/idm/base/conf/endpoint-removeRepoPathFromRelationships.json
@@ -1,0 +1,4 @@
+{
+  "type" : "text/javascript",
+  "file" : "update/removeRepoPathFromRelationships.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-repairMetadata.json
+++ b/forgecloud/default/idm/base/conf/endpoint-repairMetadata.json
@@ -1,0 +1,4 @@
+{
+    "type" : "text/javascript",
+    "file" : "meta/metadataScanner.js"
+}

--- a/forgecloud/default/idm/base/conf/endpoint-updateInternalUserAndInternalRoleEntries.json
+++ b/forgecloud/default/idm/base/conf/endpoint-updateInternalUserAndInternalRoleEntries.json
@@ -1,0 +1,4 @@
+{
+  "type" : "text/javascript",
+  "file" : "update/updateInternalUserAndInternalRoleEntries.js"
+}

--- a/forgecloud/default/idm/base/conf/external.rest.json
+++ b/forgecloud/default/idm/base/conf/external.rest.json
@@ -1,0 +1,3 @@
+{
+    "hostnameVerifier" : "&{openidm.external.rest.hostnameVerifier}"
+}

--- a/forgecloud/default/idm/base/conf/felix.webconsole.json
+++ b/forgecloud/default/idm/base/conf/felix.webconsole.json
@@ -1,0 +1,4 @@
+{
+  "username" : "admin",
+  "password" : "admin"
+}

--- a/forgecloud/default/idm/base/conf/identityProviders.json
+++ b/forgecloud/default/idm/base/conf/identityProviders.json
@@ -1,0 +1,1302 @@
+{
+    "providers" : [
+        {
+            "provider" : "google",
+            "authorizationEndpoint" : "https://accounts.google.com/o/oauth2/v2/auth",
+            "tokenEndpoint" : "https://www.googleapis.com/oauth2/v4/token",
+            "userInfoEndpoint" : "https://www.googleapis.com/oauth2/v3/userinfo",
+            "wellKnownEndpoint" : "https://accounts.google.com/.well-known/openid-configuration",
+            "clientId" : "",
+            "clientSecret" : "",
+            "uiConfig": {
+                "iconBackground": "#4184f3",
+                "iconClass": "fa-google",
+                "iconFontColor": "white",
+                "buttonImage": "images/g-logo.png",
+                "buttonClass": "",
+                "buttonCustomStyle": "background-color: #fff; color: #757575; border-color: #ddd;",
+                "buttonCustomStyleHover": "color: #6d6d6d; background-color: #eee; border-color: #ccc;",
+                "buttonDisplayName": "Google"
+            },
+            "scope" : [
+                "openid",
+                "profile",
+                "email"
+            ],
+            "authenticationIdKey" : "sub",
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Google",
+                "title" : "Google",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "sub" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "name" : {
+                        "description" : "Name",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "given_name" : {
+                        "description" : "First Name",
+                        "title" : "First Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "family_name" : {
+                        "description" : "Last Name",
+                        "title" : "Last Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "picture" : {
+                        "description" : "Profile Picture URL",
+                        "title" : "Profile Picture URL",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "email" : {
+                        "description" : "Email Address",
+                        "title" : "Email Address",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "locale" : {
+                        "description" : "Locale Code",
+                        "title" : "Locale Code",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "sub",
+                    "name",
+                    "given_name",
+                    "family_name",
+                    "picture",
+                    "email",
+                    "locale"
+                ],
+                "required" : [ ]
+            },
+            "propertyMap" : [
+                {
+                    "source" : "sub",
+                    "target" : "id"
+                },
+                {
+                    "source" : "name",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "given_name",
+                    "target" : "givenName"
+                },
+                {
+                    "source" : "family_name",
+                    "target" : "familyName"
+                },
+                {
+                    "source" : "picture",
+                    "target" : "photoUrl"
+                },
+                {
+                    "source" : "email",
+                    "target" : "email"
+                },
+                {
+                    "source" : "email",
+                    "target" : "username"
+                },
+                {
+                    "source" : "locale",
+                    "target" : "locale"
+                }
+            ],
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.oidc.OpenIDConnectClientConfiguration",
+            "basicAuth" : false
+        },
+        {
+            "provider" : "facebook",
+            "authorizationEndpoint" : "https://www.facebook.com/dialog/oauth",
+            "tokenEndpoint" : "https://graph.facebook.com/v2.7/oauth/access_token",
+            "userInfoEndpoint" : "https://graph.facebook.com/me?fields=id,name,picture,email,first_name,last_name,locale",
+            "clientId" : "",
+            "clientSecret" : "",
+            "scope" : [
+                "email",
+                "user_birthday"
+            ],
+            "uiConfig" : {
+                "iconBackground" : "#3b5998",
+                "iconClass" : "fa-facebook",
+                "iconFontColor" : "white",
+                "buttonImage" : "",
+                "buttonClass": "fa-facebook-official",
+                "buttonDisplayName" : "Facebook",
+                "buttonCustomStyle" : "background-color: #3b5998;border-color: #3b5998; color: white;",
+                "buttonCustomStyleHover" : "background-color: #334b7d;border-color: #334b7d; color: white;"
+            },
+            "basicAuth" : false,
+            "authenticationIdKey" : "id",
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Facebook",
+                "title" : "Facebook",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "id" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "name" : {
+                        "description" : "Name",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "first_name" : {
+                        "description" : "First Name",
+                        "title" : "First Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "last_name" : {
+                        "description" : "Last Name",
+                        "title" : "Last Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "email" : {
+                        "description" : "Email Address",
+                        "title" : "Email Address",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "locale" : {
+                        "description" : "Locale Code",
+                        "title" : "Locale Code",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "picture" : {
+                        "description" : "Picture",
+                        "title" : "Picture",
+                        "viewable" : true,
+                        "type" : "object",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "id",
+                    "name",
+                    "first_name",
+                    "last_name",
+                    "email",
+                    "locale",
+                    "picture"
+                ],
+                "required" : [ ]
+            },
+            "propertyMap" : [
+                {
+                    "source" : "id",
+                    "target" : "id"
+                },
+                {
+                    "source" : "name",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "first_name",
+                    "target" : "givenName"
+                },
+                {
+                    "source" : "last_name",
+                    "target" : "familyName"
+                },
+                {
+                    "source" : "email",
+                    "target" : "email"
+                },
+                {
+                    "source" : "email",
+                    "target" : "username"
+                },
+                {
+                    "source" : "locale",
+                    "target" : "locale"
+                },
+                {
+                    "source" : "picture",
+                    "target" : "photoUrl",
+                    "transform" : {
+                        "type" : "text/javascript",
+                        "source" : "source.data.url"
+                    }
+                }
+            ],
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.oauth2.OAuth2ClientConfiguration"
+        },
+        {
+            "provider" : "linkedIn",
+            "authorizationEndpoint" : "https://www.linkedin.com/oauth/v2/authorization",
+            "tokenEndpoint" : "https://www.linkedin.com/oauth/v2/accessToken",
+            "userInfoEndpoint" : "https://api.linkedin.com/v2/me?projection=(id,firstName,lastName,profilePicture(displayImage~:playableStreams))",
+            "emailAddressEndpoint" : "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))",
+            "clientId" : "",
+            "clientSecret" : "",
+            "scope" : [
+                "r_liteprofile",
+                "r_emailaddress"
+            ],
+            "authenticationIdKey" : "id",
+            "basicAuth" : false,
+            "uiConfig" : {
+                "iconBackground" : "#0077b5",
+                "iconClass" : "fa-linkedin",
+                "iconFontColor" : "white",
+                "buttonImage" : "",
+                "buttonClass" : "fa-linkedin",
+                "buttonDisplayName" : "LinkedIn",
+                "buttonCustomStyle" : "background-color:#0077b5;border-color:#0077b5;color:white;",
+                "buttonCustomStyleHover" : "background-color:#006ea9; border-color:#006ea9;color:white;"
+            },
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:LinkedIn",
+                "title" : "LinkedIn",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "id" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "firstName" : {
+                        "description" : "First Name",
+                        "title" : "First Name",
+                        "viewable" : true,
+                        "type" : "object",
+                        "searchable" : true
+                    },
+                    "lastName" : {
+                        "description" : "Last Name",
+                        "title" : "Last Name",
+                        "viewable" : true,
+                        "type" : "object",
+                        "searchable" : true
+                    },
+                    "emailAddress" : {
+                        "description" : "Email Address",
+                        "title" : "Email Address",
+                        "viewable" : true,
+                        "type" : "object",
+                        "searchable" : true
+                    },
+                    "profilePicture" : {
+                        "description" : "Profile Picture",
+                        "title" : "Profile Picture",
+                        "viewable" : true,
+                        "type" : "object",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "id",
+                    "emailAddress",
+                    "firstName",
+                    "lastName",
+                    "profilePicture"
+                ],
+                "required" : [ ]
+            },
+            "propertyMap" : [
+                {
+                    "source" : "id",
+                    "target" : "id"
+                },
+                {
+                    "source" : "firstName",
+                    "target" : "givenName",
+                    "transform" : {
+                        "type" : "text/javascript",
+                        "source" : "source.localized[Object.keys(source.localized)[0]]"
+                    }
+                },
+                {
+                    "source" : "lastName",
+                    "target" : "familyName",
+                    "transform" : {
+                        "type" : "text/javascript",
+                        "source" : "source.localized[Object.keys(source.localized)[0]]"
+                    }
+                },
+                {
+                    "source" : "elements",
+                    "target" : "email",
+                    "transform" : {
+                        "type" : "text/javascript",
+                        "source" : "source[0]['handle~'].emailAddress"
+                    }
+                },
+                {
+                    "source" : "elements",
+                    "target" : "username",
+                    "transform" : {
+                        "type" : "text/javascript",
+                        "source" : "source[0]['handle~'].emailAddress"
+                    }
+                },
+                {
+                    "source" : "profilePicture",
+                    "target" : "photoUrl",
+                        "transform" : {
+                            "type" : "text/javascript",
+                            "source" : "if(source != null) {source.displayImage}"
+                        }
+                }
+            ],
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.linkedin.LinkedInClientConfiguration"
+        },
+        {
+            "provider" : "amazon",
+            "authorizationEndpoint" : "https://www.amazon.com/ap/oa",
+            "tokenEndpoint" : "https://api.amazon.com/auth/o2/token",
+            "userInfoEndpoint" : "https://api.amazon.com/user/profile",
+            "enabled" : false,
+            "clientId" : "",
+            "clientSecret" : "",
+            "scope" : [
+                "profile"
+            ],
+            "authenticationIdKey" : "user_id",
+            "basicAuth" : false,
+            "uiConfig": {
+                "iconBackground" : "#f0c14b",
+                "iconClass" : "fa-amazon",
+                "iconFontColor" : "black",
+                "buttonImage" : "",
+                "buttonClass": "fa-amazon",
+                "buttonDisplayName" : "Amazon",
+                "buttonCustomStyle" : "background: linear-gradient(to bottom, #f7e09f 15%,#f5c646 85%);color: black;border-color: #b48c24;",
+                "buttonCustomStyleHover" : "background: linear-gradient(to bottom, #f6c94e 15%,#f6c94e 85%);color: black;border-color: #b48c24;"
+            },
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Amazon",
+                "title" : "Amazon",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "user_id" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "name" : {
+                        "description" : "Name",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "email" : {
+                        "description" : "Email Address",
+                        "title" : "Email Address",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "user_id",
+                    "name",
+                    "email"
+                ],
+                "required" : [ ]
+            },
+            "propertyMap" : [
+                {
+                    "source" : "user_id",
+                    "target" : "id"
+                },
+                {
+                    "source" : "name",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "email",
+                    "target" : "email"
+                },
+                {
+                    "source" : "email",
+                    "target" : "username"
+                }
+            ],
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.oauth2.OAuth2ClientConfiguration"
+        },
+        {
+            "provider": "wordpress",
+            "authorizationEndpoint": "https://public-api.wordpress.com/oauth2/authorize",
+            "tokenEndpoint": "https://public-api.wordpress.com/oauth2/token",
+            "userInfoEndpoint": "https://public-api.wordpress.com/rest/v1.1/me/",
+            "enabled": false,
+            "clientId": "",
+            "clientSecret": "",
+            "scope": [
+                "auth"
+            ],
+            "authenticationIdKey": "username",
+            "basicAuth" : false,
+            "uiConfig": {
+                "iconBackground" : "#0095cc",
+                "iconClass" : "fa-wordpress",
+                "iconFontColor" : "white",
+                "buttonImage" : "",
+                "buttonClass": "fa-wordpress",
+                "buttonDisplayName" : "WordPress",
+                "buttonCustomStyle" : "background-color: #0095cc; border-color: #0095cc; color:white;",
+                "buttonCustomStyleHover" : "background-color: #0095cc; border-color: #0095cc; color:white;"
+            },
+            "schema": {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Wordpress",
+                "username": "http://jsonschema.net",
+                "title": "Wordpress",
+                "viewable": true,
+                "type": "object",
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "properties": {
+                    "username": {
+                        "description": "username",
+                        "title": "username",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "email": {
+                        "description" : "email",
+                        "title": "email",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "avatar_URL": {
+                        "description" : "Avatar Url",
+                        "title": "Avatar Url",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "display_name": {
+                        "description" : "Display Name",
+                        "title": "Display Name",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    }
+                },
+                "order": [
+                    "username",
+                    "email",
+                    "display_name",
+                    "avatar_URL"
+                ],
+                "required": []
+            },
+            "propertyMap": [
+                {
+                    "source": "username",
+                    "target": "username"
+                },
+                {
+                    "source": "username",
+                    "target": "id"
+                },
+                {
+                    "source": "email",
+                    "target": "email"
+                },
+                {
+                    "source" : "avatar_URL",
+                    "target" : "photoUrl"
+                },
+                {
+                    "source" : "display_name",
+                    "target" : "displayName"
+                }
+            ],
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.oauth2.OAuth2ClientConfiguration"
+        },
+        {
+            "provider" : "microsoft",
+            "authorizationEndpoint" : "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+            "tokenEndpoint" : "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+            "userInfoEndpoint" : "https://graph.microsoft.com/v1.0/me",
+            "clientId" : "",
+            "clientSecret" : "",
+            "scope" : [
+                "User.Read"
+            ],
+            "authenticationIdKey" : "id",
+            "basicAuth" : false,
+            "uiConfig": {
+                "iconBackground": "#0078d7",
+                "iconClass": "fa-windows",
+                "iconFontColor": "white",
+                "buttonImage" : "images/microsoft-logo.png",
+                "buttonClass": "",
+                "buttonDisplayName" : "Microsoft",
+                "buttonCustomStyle" : "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;",
+                "buttonCustomStyleHover" : "background-color: #fff; border-color: #8b8b8b; color: #8b8b8b;"
+            },
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Microsoft",
+                "title": "Microsoft",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "id" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : false
+                    },
+                    "displayName" : {
+                        "description" : "Name",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "givenName" : {
+                        "description" : "First Name",
+                        "title" : "First Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "surname" : {
+                        "description" : "Last Name",
+                        "title" : "Last Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "userPrincipalName": {
+                        "description" : "Email Address",
+                        "title": "Email Address",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    }
+                },
+                "order" : [
+                    "id",
+                    "displayName",
+                    "userPrincipalName",
+                    "givenName",
+                    "surname"
+                ],
+                "required" : [ ]
+            },
+            "propertyMap": [
+                {
+                    "source" : "id",
+                    "target" : "id"
+                },
+                {
+                    "source" : "displayName",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "givenName",
+                    "target" : "givenName"
+                },
+                {
+                    "source" : "surname",
+                    "target" : "familyName"
+                },
+                {
+                    "source" : "userPrincipalName",
+                    "target" : "email"
+                },
+                {
+                    "source" : "userPrincipalName",
+                    "target" : "username"
+                }
+            ],
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.oauth2.OAuth2ClientConfiguration"
+        },
+        {
+            "provider" : "vkontakte",
+            "configClass" : "org.forgerock.oauth.clients.vk.VKClientConfiguration",
+            "basicAuth" : false,
+            "clientId" : "",
+            "clientSecret" : "",
+            "authorizationEndpoint" : "https://oauth.vk.com/authorize",
+            "tokenEndpoint" : "https://oauth.vk.com/access_token",
+            "userInfoEndpoint" : "https://api.vk.com/method/users.get?fields=photo_50",
+            "redirectUri" : "https://localhost:8443/",
+            "apiVersion" : "5.73",
+            "scope" : [
+                "email"
+            ],
+            "uiConfig": {
+                "iconBackground": "#4c75a3",
+                "iconClass": "fa-vk",
+                "iconFontColor": "white",
+                "buttonImage" : "",
+                "buttonClass": "fa-vk",
+                "buttonDisplayName" : "VK",
+                "buttonCustomStyle" : "background-color: #4c75a3; border-color: #4c75a3;color: white;",
+                "buttonCustomStyleHover" : "background-color: #43658c; border-color: #43658c;color: white;"
+            },
+            "authenticationIdKey" : "id",
+            "propertyMap" : [
+                {
+                    "source" : "id",
+                    "target" : "id"
+                },
+                {
+                    "source" : "first_name",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "first_name",
+                    "target" : "givenName"
+                },
+                {
+                    "source" : "last_name",
+                    "target" : "familyName"
+                },
+                {
+                    "source" : "email",
+                    "target" : "email"
+                },
+                {
+                    "source" : "email",
+                    "target" : "username"
+                },
+                {
+                    "source" : "photo_50",
+                    "target" : "photoUrl"
+                }
+            ],
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Vkontakte",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "id" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "name" : {
+                        "description" : "Name",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "first_name" : {
+                        "description" : "First Name",
+                        "title" : "First Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "last_name" : {
+                        "description" : "Last Name",
+                        "title" : "Last Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "email" : {
+                        "description" : "Email Address",
+                        "title" : "Email Address",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "photo_50" : {
+                        "description" : "Photo URL",
+                        "title" : "Photo URL",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "id",
+                    "name",
+                    "last_name",
+                    "first_name",
+                    "email"
+                ],
+                "required" : [ ]
+            }
+        },
+        {
+            "provider" : "instagram",
+            "configClass" : "org.forgerock.oauth.clients.instagram.InstagramClientConfiguration",
+            "basicAuth" : false,
+            "clientId" : "",
+            "clientSecret" : "",
+            "authorizationEndpoint" : "https://api.instagram.com/oauth/authorize/",
+            "tokenEndpoint" : "https://api.instagram.com/oauth/access_token",
+            "userInfoEndpoint" : "https://api.instagram.com/v1/users/self/",
+            "redirectUri" : "https://localhost:8443/",
+            "scope" : [
+                "basic",
+                "public_content"
+            ],
+            "uiConfig": {
+                "iconBackground": "#3f729b",
+                "iconClass": "fa-instagram",
+                "iconFontColor": "white",
+                "buttonImage" : "",
+                "buttonClass": "fa-instagram",
+                "buttonDisplayName" : "Instagram",
+                "buttonCustomStyle" : "background-color: #3f729b; border-color: #3f729b;color: white;",
+                "buttonCustomStyleHover" : "background-color: #305777; border-color: #305777;color: white;"
+            },
+            "connectionTimeout" : 0,
+            "readTimeout" : 0,
+            "authenticationIdKey" : "id",
+            "propertyMap" : [
+                {
+                    "source" : "id",
+                    "target" : "id"
+                },
+                {
+                    "source" : "full_name",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "profile_picture",
+                    "target" : "photoUrl"
+                },
+                {
+                    "source" : "username",
+                    "target" : "username"
+                }
+            ],
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Instagram",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "id" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "full_name" : {
+                        "description" : "Full Name",
+                        "title" : "Full Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "profile_picture" : {
+                        "description" : "Profile Picture URL",
+                        "title" : "Profile Picture URL",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "username" : {
+                        "description" : "Username",
+                        "title" : "Username",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "id",
+                    "full_name",
+                    "profile_picture",
+                    "username"
+                ],
+                "required" : [ ]
+            }
+        },
+        {
+            "provider" : "wechat",
+            "configClass" : "org.forgerock.oauth.clients.wechat.WeChatClientConfiguration",
+            "basicAuth" : false,
+            "clientId" : "",
+            "clientSecret" : "",
+            "authorizationEndpoint" : "https://open.weixin.qq.com/connect/qrconnect",
+            "tokenEndpoint" : "https://api.wechat.com/sns/oauth2/access_token",
+            "refreshTokenEndpoint" : "https://api.wechat.com/sns/oauth2/refresh_token",
+            "userInfoEndpoint" : "https://api.wechat.com/sns/userinfo",
+            "redirectUri" : "https://localhost:8443/",
+            "scope" : [
+                "snsapi_login"
+            ],
+            "uiConfig": {
+                "iconBackground": "#09b507",
+                "iconClass": "fa-weixin",
+                "iconFontColor": "white",
+                "buttonImage" : "",
+                "buttonClass": "fa-weixin",
+                "buttonDisplayName" : "WeChat",
+                "buttonCustomStyle" : "background-color: #09b507; border-color: #09b507;color: white;",
+                "buttonCustomStyleHover" : "background-color: #09a007; border-color: #09a007;color: white;"
+            },
+            "connectionTimeout" : 0,
+            "readTimeout" : 0,
+            "authenticationIdKey" : "openid",
+            "propertyMap" : [
+                {
+                    "source": "openid",
+                    "target": "id"
+                },
+                {
+                    "source": "nickname",
+                    "target": "displayName"
+                },
+                {
+                    "source": "nickname",
+                    "target": "username"
+                },
+                {
+                    "source": "headimgurl",
+                    "target": "photoUrl"
+                }
+            ],
+            "schema" : {
+                "id": "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Wechat",
+                "viewable": true,
+                "type": "object",
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "properties": {
+                    "openid": {
+                        "description" : "ID",
+                        "title": "ID",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "nickname": {
+                        "description" : "Username",
+                        "title": "Username",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "headimgurl": {
+                        "description" : "Profile Picture URL",
+                        "title": "Profile Picture URL",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    }
+                },
+                "order": [
+                    "openid",
+                    "nickname",
+                    "headimgurl"
+                ],
+                "required": []
+            }
+        },
+        {
+            "provider": "yahoo",
+            "scope": [
+                "openid",
+                "sdpp-w"
+            ],
+            "uiConfig": {
+                "iconBackground": "#7B0099",
+                "iconClass": "fa-yahoo",
+                "iconFontColor": "white",
+                "buttonImage" : "",
+                "buttonClass": "fa-yahoo",
+                "buttonDisplayName" : "Yahoo",
+                "buttonCustomStyle" : "background-color: #7B0099; border-color: #7B0099; color:white;",
+                "buttonCustomStyleHover" : "background-color: #7B0099; border-color: #7B0099; color:white;"
+            },
+            "propertyMap": [
+                {
+                    "source": "sub",
+                    "target": "id"
+                },
+                {
+                    "source": "name",
+                    "target": "displayName"
+                },
+                {
+                    "source": "given_name",
+                    "target": "givenName"
+                },
+                {
+                    "source": "family_name",
+                    "target": "familyName"
+                },
+                {
+                    "source": "email",
+                    "target": "email"
+                },
+                {
+                    "source": "email",
+                    "target": "username"
+                },
+                {
+                    "source": "locale",
+                    "target": "locale"
+                },
+                {
+                    "source": "picture",
+                    "target": "photoUrl"
+                }
+            ],
+            "schema": {
+                "id": "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Yahoo",
+                "viewable": true,
+                "type": "object",
+                "$schema": "http://json-schema.org/draft-03/schema",
+                "properties": {
+                    "sub": {
+                        "description" : "ID",
+                        "title": "ID",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "name": {
+                        "description" : "Name",
+                        "title": "Name",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "given_name": {
+                        "description" : "First Name",
+                        "title": "First Name",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "family_name": {
+                        "description" : "Last Name",
+                        "title": "Last Name",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "email": {
+                        "description" : "Email Address",
+                        "title": "Email Address",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "locale": {
+                        "description" : "Locale Code",
+                        "title": "Locale Code",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    },
+                    "picture": {
+                        "description" : "Profile Photo URL",
+                        "title": "Profile Photo URL",
+                        "viewable": true,
+                        "type": "string",
+                        "searchable": true
+                    }
+                },
+                "order": [
+                    "sub",
+                    "name",
+                    "given_name",
+                    "family_name",
+                    "email",
+                    "locale"
+                ],
+                "required": []
+            },
+            "authorizationEndpoint": "https://api.login.yahoo.com/oauth2/request_auth",
+            "tokenEndpoint": "https://api.login.yahoo.com/oauth2/get_token",
+            "wellKnownEndpoint": "https://login.yahoo.com/.well-known/openid-configuration",
+            "clientId": "",
+            "clientSecret": "",
+            "authenticationIdKey": "sub",
+            "redirectUri": "https://localhost:8443/",
+            "basicAuth": false,
+            "configClass": "org.forgerock.oauth.clients.oidc.OpenIDConnectClientConfiguration"
+        },
+        {
+            "provider" : "salesforce",
+            "authorizationEndpoint" : "https://login.salesforce.com/services/oauth2/authorize",
+            "tokenEndpoint" : "https://login.salesforce.com/services/oauth2/token",
+            "userInfoEndpoint" : "https://login.salesforce.com/services/oauth2/userinfo",
+            "clientId" : "",
+            "clientSecret" : "",
+            "scope" : [
+                "id",
+                "api",
+                "web"
+            ],
+            "uiConfig": {
+                "iconBackground": "#21a0df",
+                "iconClass": "fa-cloud",
+                "iconFontColor": "white",
+                "buttonImage" : "",
+                "buttonClass": "fa-cloud",
+                "buttonDisplayName" : "Salesforce",
+                "buttonCustomStyle" : "background-color: #21a0df; border-color: #21a0df; color: white;",
+                "buttonCustomStyleHover" : "background-color: #21a0df; border-color: #21a0df; color: white;"
+            },
+            "authenticationIdKey" : "user_id",
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.oauth2.OAuth2ClientConfiguration",
+            "basicAuth": false,
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Salesforce",
+                "title" : "Salesforce",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "user_id" : {
+                        "description" : "ID",
+                        "title" : "ID",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "name" : {
+                        "description" : "Name",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "given_name" : {
+                        "description" : "First Name",
+                        "title" : "First Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "family_name" : {
+                        "description" : "Last Name",
+                        "title" : "Last Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "email" : {
+                        "description" : "Email Address",
+                        "title" : "Email Address",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "zoneInfo" : {
+                        "description" : "Locale Code",
+                        "title" : "Locale Code",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "picture" : {
+                        "description" : "Picture URL",
+                        "title" : "Picture URL",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "user_id",
+                    "name",
+                    "given_name",
+                    "family_name",
+                    "email",
+                    "zoneInfo",
+                    "picture"
+                ],
+                "required" : [ ]
+            },
+            "propertyMap" : [
+                {
+                    "source" : "user_id",
+                    "target" : "id"
+                },
+                {
+                    "source" : "name",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "given_name",
+                    "target" : "givenName"
+                },
+                {
+                    "source" : "family_name",
+                    "target" : "familyName"
+                },
+                {
+                    "source" : "email",
+                    "target" : "email"
+                },
+                {
+                    "source" : "email",
+                    "target" : "username"
+                },
+                {
+                    "source" : "zoneInfo",
+                    "target" : "locale"
+                },
+                {
+                    "source" : "picture",
+                    "target" : "photoUrl"
+                }
+            ]
+        },
+        {
+            "provider" : "twitter",
+            "requestTokenEndpoint" : "https://api.twitter.com/oauth/request_token",
+            "authorizationEndpoint" : "https://api.twitter.com/oauth/authenticate",
+            "tokenEndpoint" : "https://api.twitter.com/oauth/access_token",
+            "userInfoEndpoint" : "https://api.twitter.com/1.1/account/verify_credentials.json",
+            "clientId" : "",
+            "clientSecret" : "",
+            "uiConfig" : {
+                "iconBackground" : "#00b6e9",
+                "iconClass" : "fa-twitter",
+                "iconFontColor" : "white",
+                "buttonImage" : "",
+                "buttonClass" : "fa-twitter",
+                "buttonDisplayName" : "Twitter",
+                "buttonCustomStyle" : "background-color: #00b6e9; border-color: #00b6e9; color: #fff;",
+                "buttonCustomStyleHover" : "background-color: #01abda; border-color: #01abda; color: #fff;"
+            },
+            "authenticationIdKey" : "id_str",
+            "redirectUri" : "https://localhost:8443/",
+            "configClass" : "org.forgerock.oauth.clients.twitter.TwitterClientConfiguration",
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:identityProviders:api:Twitter",
+                "title" : "Twitter",
+                "viewable" : true,
+                "type" : "object",
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "properties" : {
+                    "id_str" : {
+                        "description" : "ID",
+                        "title" : "Id",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "name" : {
+                        "description" : "Full Name",
+                        "title" : "Full Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "screen_name" : {
+                        "description" : "User Id",
+                        "title" : "User Id",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "email" : {
+                        "description" : "Email Address",
+                        "title" : "Email Address",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    },
+                    "profile_image_url" : {
+                        "description" : "Profile Image URL",
+                        "title" : "Profile Image URL",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true
+                    }
+                },
+                "order" : [
+                    "id_str",
+                    "name",
+                    "screen_name",
+                    "email",
+                    "profile_image_url"
+                ],
+                "required" : [ ]
+            },
+            "propertyMap" : [
+                {
+                    "source" : "id_str",
+                    "target" : "id"
+                },
+                {
+                    "source" : "name",
+                    "target" : "displayName"
+                },
+                {
+                    "source" : "email",
+                    "target" : "email"
+                },
+                {
+                    "source" : "screen_name",
+                    "target" : "username"
+                },
+                {
+                    "source" : "profile_image_url",
+                    "target" : "photoUrl"
+                }
+            ]
+        }
+    ]
+}

--- a/forgecloud/default/idm/base/conf/internal.json
+++ b/forgecloud/default/idm/base/conf/internal.json
@@ -1,0 +1,58 @@
+{
+  "objects" : [
+    {
+      "name" : "user",
+      "properties" : {
+        "authzRoles" : {
+          "items" : {
+            "resourceCollection" : [
+              {
+                "path" : "managed/role",
+                "label" : "Role",
+                "query" : {
+                  "queryFilter" : "true",
+                  "fields" : [
+                    "name"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name" : "role",
+      "properties" : {
+        "authzMembers" : {
+          "items" : {
+            "resourceCollection" : [
+              {
+                "path" : "managed/user",
+                "conditionalAssociation" : true,
+                "notify" : true,
+                "label" : "User",
+                "query" : {
+                  "queryFilter" : "true",
+                  "fields" : [
+                    "userName",
+                    "givenName",
+                    "sn"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name" : "notification",
+      "properties" : {
+        "target" : {
+          "reversePropertyName" : "_notifications"
+        }
+      }
+    }
+  ]
+}

--- a/forgecloud/default/idm/base/conf/java.security
+++ b/forgecloud/default/idm/base/conf/java.security
@@ -1,0 +1,17 @@
+#
+# Copyright 2018 ForgeRock AS. All Rights Reserved
+#
+# Use of this code requires a commercial software license with ForgeRock AS.
+# or with one of its affiliates. All use shall be exclusively subject
+# to such license between the licensee and ForgeRock AS.
+#
+
+# Use this file to extend the properties defined in the JDK java.security file.
+
+# This is an example of how to add a PKCS11 (HSM) provider for JDK8. It is important to make sure the provider number is
+# not already taken.
+# security.provider.11=sun.security.pkcs11.SunPKCS11 /path/to/pkc11/config/pkcs11.conf
+
+# This is an example of how to add a PKCS11 (HSM) provider for JDK9+. It is important to make sure the provider number is
+# not already taken.
+# security.provider.14=SunPKCS11 /path/to/pkc11/config/pkcs11.conf

--- a/forgecloud/default/idm/base/conf/jetty.xml
+++ b/forgecloud/default/idm/base/conf/jetty.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
+<!--
+  Copyright 2015-2019 ForgeRock AS. All Rights Reserved
+
+  Use of this code requires a commercial software license with ForgeRock AS.
+  or with one of its affiliates. All use shall be exclusively subject
+  to such license between the licensee and ForgeRock AS.
+-->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+    <!-- =========================================================== -->
+    <!-- Set connectors                                              -->
+    <!-- =========================================================== -->
+    <!-- One of each type!                                           -->
+    <!-- =========================================================== -->
+
+    <!--<Arg name="threadpool">
+        <New class="org.eclipse.jetty.util.thread.QueuedThreadPool">
+            <Arg name="maxThreads">500</Arg>
+            <Arg name="minThreads">50</Arg>
+            <Arg name="idleTimeout">60000</Arg>
+            <Arg name="queue">
+                <New class="java.util.concurrent.ArrayBlockingQueue">
+                    <Arg type="int">6000</Arg>
+                </New>
+            </Arg>
+            <Set name="minThreads">50</Set>
+            <Set name="maxThreads">500</Set>
+            <Set name="detailedDump">false</Set>
+        </New>
+    </Arg>-->
+
+    <New id="httpSimpleConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+        <!-- remove Server header from HTTP responses, to prevent leaking server-type/version -->
+        <Set name="sendServerVersion">false</Set>
+        <Set name="outputBufferSize">32768</Set>
+        <Set name="requestHeaderSize">16384</Set>
+        <Set name="responseHeaderSize">8192</Set>
+    </New>
+
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+        <Arg><Ref refid="httpSimpleConfig"/></Arg>
+        <Call name="addCustomizer">
+            <Arg>
+                <New class="org.eclipse.jetty.server.ForwardedRequestCustomizer">
+                    <!-- Prevent host header changes that may occur from URL hijacking attempts -->
+                    <Set name="hostHeader">
+                        <Call class="org.forgerock.openidm.jetty.Param" name="getProperty">
+                            <Arg>openidm.host</Arg>
+                        </Call>:<Call class="org.forgerock.openidm.jetty.Param" name="getProperty">
+                        <Arg>openidm.port.http</Arg>
+                    </Call>
+                    </Set>
+                </New>
+            </Arg>
+        </Call>
+    </New>
+
+    <New id="tlsHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+        <Arg><Ref refid="httpSimpleConfig"/></Arg>
+        <Set name="secureScheme">https</Set>
+        <Set name="securePort">
+            <Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                <Arg>openidm.port.https</Arg>
+            </Call>
+        </Set>
+        <Call name="addCustomizer">
+            <Arg>
+                <New class="org.eclipse.jetty.server.SecureRequestCustomizer">
+                    <!-- Enable SNI Host Check when true -->
+                    <Arg name="sniHostCheck" type="boolean">true</Arg>
+                    <!-- Enable Strict-Transport-Security header and define max-age when >= 0 seconds -->
+                    <Arg name="stsMaxAgeSeconds" type="long">-1</Arg>
+                    <!-- If enabled, add includeSubDomains to Strict-Transport-Security header when true -->
+                    <Arg name="stsIncludeSubdomains" type="boolean">false</Arg>
+                </New>
+            </Arg>
+        </Call>
+        <Call name="addCustomizer">
+            <Arg>
+                <New class="org.eclipse.jetty.server.ForwardedRequestCustomizer">
+                    <!-- Prevent host header changes that may occur from URL hijacking attempts -->
+                    <Set name="hostHeader">
+                        <Call class="org.forgerock.openidm.jetty.Param" name="getProperty">
+                            <Arg>openidm.host</Arg>
+                        </Call>:<Call class="org.forgerock.openidm.jetty.Param" name="getProperty">
+                        <Arg>openidm.port.https</Arg>
+                    </Call>
+                    </Set>
+                </New>
+            </Arg>
+        </Call>
+    </New>
+
+    <New id="mutualAuthHttpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+        <Arg><Ref refid="httpSimpleConfig"/></Arg>
+        <Set name="secureScheme">https</Set>
+        <Set name="securePort">
+            <Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                <Arg>openidm.port.mutualauth</Arg>
+            </Call>
+        </Set>
+        <Call name="addCustomizer">
+            <Arg><New class="org.eclipse.jetty.server.SecureRequestCustomizer"/></Arg>
+        </Call>
+        <Call name="addCustomizer">
+            <Arg>
+                <New class="org.eclipse.jetty.server.ForwardedRequestCustomizer">
+                    <!-- Prevent host header changes that may occur from URL hijacking attempts -->
+                    <Set name="hostHeader">
+                        <Call class="org.forgerock.openidm.jetty.Param" name="getProperty">
+                            <Arg>openidm.host</Arg>
+                        </Call>:<Call class="org.forgerock.openidm.jetty.Param" name="getProperty">
+                        <Arg>openidm.port.mutualauth</Arg>
+                    </Call>
+                    </Set>
+                </New>
+            </Arg>
+        </Call>
+    </New>
+
+    <Array id="excludedCipherSuites" type="java.lang.String">
+        <!-- EXP-RC4-MD5  -->
+        <!-- RC4-MD5 -->
+        <Item>.*RC4.*MD5</Item>
+
+        <!-- RC4-SHA  -->
+        <!--ECDHE-RSA-RC4-SHA -->
+        <Item>.*RC4.*SHA</Item>
+
+        <!-- EDE_CBC_SHA -->
+        <!--EDH-RSA-DES-CBC-SHA or DHE-RSA-DES-CBC-SHA -->
+        <!-- EXP-EDH-RSA-DES-CBC-SHA or EXP-DHE-RSA-DES-CBC-SHA  -->
+        <!-- EXP-DES-CBC-SHA -->
+        <!-- DES-CBC-SHA -->
+        <Item>.*DES.*</Item>
+
+    </Array>
+
+    <Array  id= "excludedProtocols" type="java.lang.String">
+        <Item>SSLv3</Item>
+        <Item>TLSv1</Item>
+    </Array>
+
+    <New id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+        <Set name="keyStorePath"><Get class="org.forgerock.openidm.jetty.Param" name="keystoreLocation"/></Set>
+        <Set name="keyStorePassword"><Get class="org.forgerock.openidm.jetty.Param" name="keystorePassword"/></Set>
+        <Set name="keyStoreType"><Get class="org.forgerock.openidm.jetty.Param" name="keystoreType"/></Set>
+        <Set name="keyStoreProvider"><Get class="org.forgerock.openidm.jetty.Param" name="keystoreProvider" /></Set>
+        <Set name="trustStoreProvider"><Get class="org.forgerock.openidm.jetty.Param" name="truststoreProvider" /></Set>
+        <Set name="trustStoreType"><Get class="org.forgerock.openidm.jetty.Param" name="truststoreType"/></Set>
+        <Set name="trustStorePath"><Get class="org.forgerock.openidm.jetty.Param" name="truststoreLocation"/></Set>
+        <Set name="trustStorePassword"><Get class="org.forgerock.openidm.jetty.Param" name="truststorePassword"/></Set>
+        <Set name="certAlias"><Get class="org.forgerock.openidm.jetty.Param" name="certAlias"/></Set>
+        <Set name="ExcludeProtocols">
+            <Ref refid="excludedProtocols"/>
+        </Set>
+        <Set name="ExcludeCipherSuites">
+            <Ref refid="excludedCipherSuites"/>
+        </Set>
+    </New>
+
+    <New id="sslContextFactoryMutualAuth" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+        <Set name="keyStorePath"><Get class="org.forgerock.openidm.jetty.Param" name="keystoreLocation"/></Set>
+        <Set name="keyStorePassword"><Get class="org.forgerock.openidm.jetty.Param" name="keystorePassword"/></Set>
+        <Set name="keyStoreType"><Get class="org.forgerock.openidm.jetty.Param" name="keystoreType"/></Set>
+        <Set name="keyStoreProvider"><Get class="org.forgerock.openidm.jetty.Param" name="keystoreProvider" /></Set>
+        <Set name="trustStoreProvider"><Get class="org.forgerock.openidm.jetty.Param" name="truststoreProvider" /></Set>
+        <Set name="trustStoreType"><Get class="org.forgerock.openidm.jetty.Param" name="truststoreType"/></Set>
+        <Set name="trustStorePath"><Get class="org.forgerock.openidm.jetty.Param" name="truststoreLocation"/></Set>
+        <Set name="trustStorePassword"><Get class="org.forgerock.openidm.jetty.Param" name="truststorePassword"/></Set>
+        <Set name="needClientAuth">true</Set>
+        <Set name="certAlias"><Get class="org.forgerock.openidm.jetty.Param" name="certAlias"/></Set>
+        <Set name="ExcludeProtocols">
+            <Ref refid="excludedProtocols"/>
+        </Set>
+        <Set name="ExcludeCipherSuites">
+            <Ref refid="excludedCipherSuites"/>
+        </Set>
+    </New>
+
+    <Call name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.server.ServerConnector">
+                <Arg name="server"><Ref refid="Server" /></Arg>
+                <Arg name="executor"/>
+                <Arg name="scheduler"/>
+                <Arg name="bufferPool"/>
+                <Arg name="acceptors" type="int">-1</Arg>
+                <Arg name="selectors" type="int">-1</Arg>
+                <Arg name="factories">
+                    <Array type="org.eclipse.jetty.server.ConnectionFactory">
+                        <Item>
+                            <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                                <Arg name="config"><Ref refid="httpConfig" /></Arg>
+                            </New>
+                        </Item>
+                    </Array>
+                </Arg>
+                <Set name="port">
+                    <Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                        <Arg>openidm.port.http</Arg>
+                    </Call>
+                </Set>
+                <Set name="idleTimeout">300000</Set>
+                <Set name="name">
+                    <Property name="jetty.host" default="0.0.0.0" />:<Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                    <Arg>openidm.port.http</Arg>
+                </Call>
+                </Set>
+            </New>
+        </Arg>
+    </Call>
+
+    <Call id="sslConnector" name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.server.ServerConnector">
+                <Arg name="server"><Ref refid="Server" /></Arg>
+                <Arg name="executor"/>
+                <Arg name="scheduler"/>
+                <Arg name="bufferPool"/>
+                <Arg name="acceptors" type="int">-1</Arg>
+                <Arg name="selectors" type="int">-1</Arg>
+                <Arg name="factories">
+                    <Array type="org.eclipse.jetty.server.ConnectionFactory">
+                        <Item>
+                            <New class="org.eclipse.jetty.server.SslConnectionFactory">
+                                <Arg name="next">http/1.1</Arg>
+                                <Arg name="sslContextFactory"><Ref refid="sslContextFactory"/></Arg>
+                            </New>
+                        </Item>
+                        <Item>
+                            <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                                <Arg name="config"><Ref refid="tlsHttpConfig"/></Arg>
+                            </New>
+                        </Item>
+                    </Array>
+                </Arg>
+                <Set name="port">
+                    <Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                        <Arg>openidm.port.https</Arg>
+                    </Call>
+                </Set>
+                <Set name="idleTimeout">30000</Set>
+                <Set name="name">
+                    <Property name="jetty.host" default="0.0.0.0" />:<Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                    <Arg>openidm.port.https</Arg>
+                </Call>
+                </Set>
+            </New>
+        </Arg>
+    </Call>
+
+    <Call name="addConnector">
+        <Arg>
+            <New class="org.eclipse.jetty.server.ServerConnector" id="MutualAuthPort">
+                <Arg name="server"><Ref refid="Server" /></Arg>
+                <Arg name="factories">
+                    <Array type="org.eclipse.jetty.server.ConnectionFactory">
+                        <Item>
+                            <New class="org.eclipse.jetty.server.SslConnectionFactory">
+                                <Arg name="next">http/1.1</Arg>
+                                <Arg name="sslContextFactory">
+                                    <Ref refid="sslContextFactoryMutualAuth"/>
+                                </Arg>
+                            </New>
+                        </Item>
+                        <Item>
+                            <New class="org.eclipse.jetty.server.HttpConnectionFactory">
+                                <Arg name="config"><Ref refid="mutualAuthHttpConfig"/></Arg>
+                            </New>
+                        </Item>
+                    </Array>
+                </Arg>
+                <Set name="port">
+                    <Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                        <Arg>openidm.port.mutualauth</Arg>
+                    </Call>
+                </Set>
+                <Set name="idleTimeout">30000</Set>
+                <Set name="name">
+                    <Property name="jetty.host" default="0.0.0.0" />:<Call class="org.forgerock.openidm.jetty.Param"  name="getProperty">
+                    <Arg>openidm.port.mutualauth</Arg>
+                </Call>
+                </Set>
+                <!--Call class="org.forgerock.openidm.jetty.DisableOpenIDMAuth"
+        name="add">
+                    <Arg>
+                        <Ref refid="MutualAuthPort"/>
+                    </Arg>
+                </Call-->
+            </New>
+        </Arg>
+    </Call>
+
+    <Call name="insertHandler">
+        <Arg>
+            <!-- https://www.eclipse.org/jetty/documentation/9.4.x/gzip-filter.html -->
+            <New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
+                <Set name="minGzipSize"><Property name="jetty.gzip.minGzipSize" default="2048"/></Set>
+                <Set name="checkGzExists"><Property name="jetty.gzip.checkGzExists" default="false"/></Set>
+                <Set name="compressionLevel"><Property name="jetty.gzip.compressionLevel" default="-1"/></Set>
+                <Set name="inflateBufferSize"><Property name="jetty.gzip.inflateBufferSize" default="0"/></Set>
+                <Set name="syncFlush"><Property name="jetty.gzip.syncFlush" default="false" /></Set>
+                <Set name="excludedAgentPatterns">
+                    <Array type="String">
+                        <!-- IE 6 has known bugs related to GZIP compression -->
+                        <Item><Property name="jetty.gzip.excludedUserAgent" default=".*MSIE.6\.0.*"/></Item>
+                    </Array>
+                </Set>
+                <Set name="includedMethodList"><Property name="jetty.gzip.includedMethodList" default="GET" /></Set>
+                <Set name="excludedMethodList"><Property name="jetty.gzip.excludedMethodList" default="" /></Set>
+            </New>
+        </Arg>
+    </Call>
+
+</Configure>

--- a/forgecloud/default/idm/base/conf/jsonstore.json
+++ b/forgecloud/default/idm/base/conf/jsonstore.json
@@ -1,0 +1,4 @@
+{
+  "cleanupDwellSeconds" : 600,
+  "entryExpireSeconds" : 1800
+}

--- a/forgecloud/default/idm/base/conf/logging.properties
+++ b/forgecloud/default/idm/base/conf/logging.properties
@@ -1,0 +1,141 @@
+# Properties file which configures the operation of the JDK
+# logging facility.
+
+# The system will look for this config file, first using
+# a System property specified at startup:
+#
+# >java -Djava.util.logging.config.file=myLoggingConfigFilePath
+#
+# If this property is not specified, then the config file is
+# retrieved from its default location at:
+#
+# JDK_HOME/jre/lib/logging.properties
+
+############################################################
+#      Global properties
+############################################################
+# ------------------------------------------
+# The set of handlers to be loaded upon startup.
+# Comma-separated list of class names.
+# (? LogManager docs say no comma here, but JDK example has comma.)
+# StreamHandler: A simple handler for writing formatted records to an OutputStream.
+# ConsoleHandler: A simple handler for writing formatted records to System.err
+# FileHandler: A handler that writes formatted log records either to a single file, or to a set of rotating log files.
+# SocketHandler: A handler that writes formatted log records to remote TCP ports.
+# MemoryHandler: A handler that buffers log records in memory.
+# handlers=java.util.logging.ConsoleHandler
+handlers=java.util.logging.FileHandler, java.util.logging.ConsoleHandler
+
+# Default global logging level.
+# This specifies which kinds of events are logged across
+# all loggers.  For any given facility this global level
+# can be overriden by a facility specific level
+# Note that the ConsoleHandler also has a separate level
+# setting to limit messages printed to the console.
+# Loggers and Handlers may override this level
+.level=INFO
+
+# Loggers
+# ------------------------------------------
+# Loggers are usually attached to packages.
+# Here, the level for each package is specified.
+# The global level is used by default, so levels
+# specified here simply act as an override.
+# The levels in descending order are:
+#   SEVERE (highest value)
+#   WARNING
+#   INFO
+#   CONFIG
+#   FINE
+#   FINER
+#   FINEST (lowest value)
+
+# Logging format
+# Adding the %1$tL field to the JDK default format to log timestamps with milliseconds
+java.util.logging.SimpleFormatter.format = %1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS.%1$tL %1$Tp %2$s%n%4$s: %5$s%6$s%n
+
+############################################################
+# Facility specific properties.
+# Provides extra control for each logger.
+############################################################
+#org.forgerock.openidm.provisioner.level = FINER
+#org.forgerock.openidm.repo.level = FINER
+#org.forgerock.openidm.recon.level = FINER
+
+# OpenICF is noisy at INFO level
+org.forgerock.openicf.level=WARNING
+
+# Commons api.models (API Descriptor) is noisy at INFO level
+org.forgerock.api.models.level=WARNING
+
+# Logs the output from OSGi logging
+org.forgerock.openidm.Framework.level=WARNING
+
+# On restart the BarURLHandler can create warning noise
+org.activiti.osgi.BarURLHandler.level=SEVERE
+
+# Suppress warnings of failed connector loading
+org.identityconnectors.framework.impl.api.local.LocalConnectorInfoManagerImpl.level=SEVERE
+
+# Log all detail for update processes
+org.forgerock.openidm.maintenance.upgrade.level=FINEST
+
+# Suppress messages lower than warnings
+org.forgerock.secrets.keystore.level=WARNING
+
+# Sets the SchemaField log level to INFO by default because if logging is set to FINE or higher,
+# sensitive information can be leaked into the logs
+org.forgerock.openidm.schema.SchemaField.level=INFO
+
+# reduce the logging of embedded postgres since it is very verbose
+ru.yandex.qatools.embed.postgresql.level = SEVERE
+
+# Logs the output from Jetty
+# Sets the following Jetty classes to INFO level by default because if logging is set to FINE or higher,
+# sensitive information can be leaked into the logs
+org.eclipse.jetty.level=INFO
+
+# Mute intermittent `Error page loop` warning, which does not indicate a real problem
+org.eclipse.jetty.server.handler.ErrorHandler.level=SEVERE
+
+############################################################
+# Handler specific properties.
+# Describes specific configuration info for Handlers.
+############################################################
+
+# --- ConsoleHandler ---
+# Default: java.util.logging.ConsoleHandler.level = INFO
+# Override of global logging level
+java.util.logging.ConsoleHandler.level = WARNING
+java.util.logging.ConsoleHandler.formatter = org.forgerock.openidm.logger.ThreadIdLogFormatter
+# specifies the name of the filter class to be associated with this handler,
+# defaults to {@code null} if this property is not found or has an invalid value.
+java.util.logging.ConsoleHandler.filter=org.forgerock.openidm.config.logging.util.LogFilter
+
+# --- FileHandler ---
+# Override of global logging level
+java.util.logging.FileHandler.level = ALL
+
+# Naming style for the output file:
+# (The output file is placed in the directory
+# defined by the "user.home" System property.)
+# java.util.logging.FileHandler.pattern = %h/java%u.log
+java.util.logging.FileHandler.pattern = logs/openidm%u.log
+
+# Limiting size of output file in bytes:
+java.util.logging.FileHandler.limit = 5242880
+
+# Number of output files to cycle through, by appending an
+# integer to the base file name:
+java.util.logging.FileHandler.count = 5
+
+# Style of output (Simple or XML):
+# Writes brief "human-readable" summaries of log records.
+java.util.logging.FileHandler.formatter = org.forgerock.openidm.logger.ThreadIdLogFormatter
+
+# Writes detailed XML-structured information.
+# java.util.logging.FileHandler.formatter = java.util.logging.XMLFormatter
+
+# specifies the character set encoding name.
+# defaults to the default platform encoding
+java.util.logging.FileHandler.encoding = UTF-8

--- a/forgecloud/default/idm/base/conf/managed.json
+++ b/forgecloud/default/idm/base/conf/managed.json
@@ -1,0 +1,1227 @@
+{
+    "objects" : [
+        {
+            "name" : "user",
+            "onCreate" : {
+                "type" : "text/javascript",
+                "source" : "require('onCreateUser').setDefaultFields(object);require('onCreateUser').emailUser(object);"
+            },
+            "onUpdate" : {
+                "type" : "text/javascript",
+                "source" : "require('onUpdateUser').preserveLastSync(object, oldObject, request);"
+            },
+            "postDelete" : {
+                "type" : "text/javascript",
+                "source" : "require('postDelete-idp-cleanup').removeConnectedIdpData(oldObject, resourceName, request);require('postDelete-notification-cleanup').removeConnectedNotificationData(oldObject, resourceName, request);"
+            },
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:User",
+                "title" : "User",
+                "icon" : "fa-user",
+                "viewable" : true,
+                "$schema" : "http://json-schema.org/draft-03/schema",
+                "order" : [
+                    "_id",
+                    "userName",
+                    "password",
+                    "givenName",
+                    "sn",
+                    "mail",
+                    "description",
+                    "accountStatus",
+                    "telephoneNumber",
+                    "postalAddress",
+                    "address2",
+                    "city",
+                    "postalCode",
+                    "country",
+                    "stateProvince",
+                    "roles",
+                    "manager",
+                    "authzRoles",
+                    "reports",
+                    "effectiveRoles",
+                    "effectiveAssignments",
+                    "lastSync",
+                    "kbaInfo",
+                    "preferences",
+                    "consentedMappings"
+                ],
+                "properties" : {
+                    "_id" : {
+                        "description" : "User ID",
+                        "type" : "string",
+                        "viewable" : false,
+                        "searchable" : false,
+                        "userEditable" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "cannot-contain-characters",
+                                "params" : {
+                                    "forbiddenChars" : [
+                                        "/"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "password" : {
+                        "title" : "Password",
+                        "description" : "Password",
+                        "type" : "string",
+                        "viewable" : false,
+                        "searchable" : false,
+                        "userEditable" : true,
+                        "encryption" : {
+                            "purpose": "idm.password.encryption"
+                        },
+                        "scope" : "private",
+                        "isProtected": true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 8
+                                }
+                            },
+                            {
+                                "policyId" : "at-least-X-capitals",
+                                "params" : {
+                                    "numCaps" : 1
+                                }
+                            },
+                            {
+                                "policyId" : "at-least-X-numbers",
+                                "params" : {
+                                    "numNums" : 1
+                                }
+                            },
+                            {
+                                "policyId" : "cannot-contain-others",
+                                "params" : {
+                                    "disallowedFields" : [
+                                        "userName",
+                                        "givenName",
+                                        "sn"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "kbaInfo" : {
+                        "description" : "KBA Info",
+                        "type" : "array",
+                        "userEditable" : true,
+                        "viewable" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "items" : {
+                            "type" : "object",
+                            "title" : "KBA Info Items",
+                            "properties" : {
+                                "answer" : {
+                                    "description" : "Answer",
+                                    "type" : "string"
+                                },
+                                "customQuestion" : {
+                                    "description" : "Custom question",
+                                    "type" : "string"
+                                },
+                                "questionId" : {
+                                    "description" : "Question ID",
+                                    "type" : "string"
+                                }
+                            },
+                            "order": [
+                                "answer",
+                                "customQuestion",
+                                "questionId"
+                            ],
+                            "required": []
+                        }
+                    },
+                    "preferences" : {
+                        "title" : "Preferences",
+                        "description" : "Preferences",
+                        "viewable" : true,
+                        "searchable" : false,
+                        "userEditable" : true,
+                        "type" : "object",
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "properties" : {
+                            "updates" : {
+                                "description" : "Send me news and updates",
+                                "type" : "boolean"
+                            },
+                            "marketing": {
+                                "description" : "Send me special offers and services",
+                                "type" : "boolean"
+                            }
+                        },
+                        "order": [
+                            "updates",
+                            "marketing"
+                        ],
+                        "required": []
+                    },
+                    "mail" : {
+                        "title" : "Email Address",
+                        "description" : "Email Address",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "policies" : [
+                            {
+                                "policyId" : "valid-email-address-format"
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "sn" : {
+                        "title" : "Last Name",
+                        "description" : "Last Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "description" : {
+                        "title" : "Description",
+                        "description" : "Description",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "address2" : {
+                        "type" : "string",
+                        "title" : "Address 2",
+                        "description" : "Address 2",
+                        "viewable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "givenName" : {
+                        "title" : "First Name",
+                        "description" : "First Name",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "city" : {
+                        "type" : "string",
+                        "title" : "City",
+                        "description" : "City",
+                        "viewable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "country" : {
+                        "type" : "string",
+                        "title" : "Country",
+                        "description" : "Country",
+                        "viewable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "postalCode" : {
+                        "type" : "string",
+                        "title" : "Postal Code",
+                        "description" : "Postal Code",
+                        "viewable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "accountStatus" : {
+                        "title" : "Status",
+                        "description" : "Status",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true,
+                        "userEditable" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "roles" : {
+                        "description" : "Provisioning Roles",
+                        "title" : "Provisioning Roles",
+                        "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:User:roles",
+                        "viewable" : true,
+                        "userEditable" : false,
+                        "returnByDefault" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "type" : "array",
+                        "relationshipGrantTemporalConstraintsEnforced" : true,
+                        "items" : {
+                            "type" : "relationship",
+                            "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:User:roles:items",
+                            "title" : "Provisioning Roles Items",
+                            "reverseRelationship" : true,
+                            "reversePropertyName" : "members",
+                            "notifySelf" : true,
+                            "validate" : true,
+                            "properties" : {
+                                "_ref" : {
+                                    "description" : "References a relationship from a managed object",
+                                    "type" : "string"
+                                },
+                                "_refProperties" : {
+                                    "description" : "Supports metadata within the relationship",
+                                    "type" : "object",
+                                    "title" : "Provisioning Roles Items _refProperties",
+                                    "properties" : {
+                                        "_id" : {
+                                            "description" : "_refProperties object ID",
+                                            "type" : "string"
+                                        },
+                                        "_grantType" : {
+                                            "description" : "Grant Type",
+                                            "type" : "string",
+                                            "label" : "Grant Type"
+                                        }
+                                    }
+                                }
+                            },
+                            "resourceCollection" : [
+                                {
+                                    "path" : "managed/role",
+                                    "label" : "Role",
+                                    "conditionalAssociationField" : "condition",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "authzRoles" : {
+                        "description" : "Authorization Roles",
+                        "title" : "Authorization Roles",
+                        "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:User:authzRoles",
+                        "viewable" : true,
+                        "type" : "array",
+                        "userEditable" : false,
+                        "returnByDefault" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "items" : {
+                            "type" : "relationship",
+                            "title" : "Authorization Roles Items",
+                            "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:User:authzRoles:items",
+                            "reverseRelationship" : true,
+                            "reversePropertyName" : "authzMembers",
+                            "validate" : true,
+                            "properties" : {
+                                "_ref" : {
+                                    "description" : "References a relationship from a managed object",
+                                    "type" : "string"
+                                },
+                                "_refProperties" : {
+                                    "description" : "Supports metadata within the relationship",
+                                    "type" : "object",
+                                    "title" : "Authorization Roles Items _refProperties",
+                                    "properties" : {
+                                        "_id" : {
+                                            "description" : "_refProperties object ID",
+                                            "type" : "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "resourceCollection" : [
+                                {
+                                    "path" : "internal/role",
+                                    "label" : "Internal Role",
+                                    "conditionalAssociationField" : "condition",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "name"
+                                        ]
+                                    }
+                                },
+                                {
+                                    "path" : "managed/role",
+                                    "label" : "Role",
+                                    "conditionalAssociationField" : "condition",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "reports" : {
+                        "description" : "Direct Reports",
+                        "title" : "Direct Reports",
+                        "viewable" : true,
+                        "userEditable" : false,
+                        "type" : "array",
+                        "returnByDefault" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "items" : {
+                            "type" : "relationship",
+                            "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:User:reports:items",
+                            "title" : "Direct Reports Items",
+                            "reverseRelationship" : true,
+                            "reversePropertyName" : "manager",
+                            "validate" : true,
+                            "properties" : {
+                                "_ref" : {
+                                    "description" : "References a relationship from a managed object",
+                                    "type" : "string"
+                                },
+                                "_refProperties" : {
+                                    "description" : "Supports metadata within the relationship",
+                                    "type" : "object",
+                                    "title" : "Direct Reports Items _refProperties",
+                                    "properties" : {
+                                        "_id" : {
+                                            "description" : "_refProperties object ID",
+                                            "type" : "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "resourceCollection" : [
+                                {
+                                    "path" : "managed/user",
+                                    "label" : "User",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "userName",
+                                            "givenName",
+                                            "sn"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "effectiveRoles" : {
+                        "type" : "array",
+                        "title" : "Effective Roles",
+                        "description" : "Effective Roles",
+                        "viewable" : false,
+                        "returnByDefault" : true,
+                        "isVirtual" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "onRetrieve" : {
+                            "type" : "text/javascript",
+                             "source" : "require('roles/effectiveRoles').calculateEffectiveRoles(object, 'roles');"
+                        },
+                        "items" : {
+                            "type" : "object",
+                            "title" : "Effective Roles Items"
+                        }
+                    },
+                    "effectiveAssignments" : {
+                        "type" : "array",
+                        "title" : "Effective Assignments",
+                        "description" : "Effective Assignments",
+                        "viewable" : false,
+                        "returnByDefault" : true,
+                        "isVirtual" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "onRetrieve" : {
+                            "type" : "text/javascript",
+                            "file" : "roles/effectiveAssignments.js",
+                            "effectiveRolesPropName" : "effectiveRoles"
+                        },
+                        "items" : {
+                            "type" : "object",
+                            "title" : "Effective Assignments Items"
+                        }
+                    },
+                    "telephoneNumber" : {
+                        "type" : "string",
+                        "title" : "Telephone Number",
+                        "description" : "Telephone Number",
+                        "viewable" : true,
+                        "userEditable" : true,
+                        "pattern" : "^\\+?([0-9\\- \\(\\)])*$",
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "stateProvince" : {
+                        "type" : "string",
+                        "title" : "State/Province",
+                        "description" : "State/Province",
+                        "viewable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "postalAddress" : {
+                        "type" : "string",
+                        "title" : "Address 1",
+                        "description" : "Address 1",
+                        "viewable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "policies" : [
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId": "maximum-length",
+                                "params": {
+                                    "maxLength": 255
+                                }
+                            }
+                        ]
+                    },
+                    "userName" : {
+                        "title" : "Username",
+                        "description" : "Username",
+                        "viewable" : true,
+                        "type" : "string",
+                        "searchable" : true,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : true,
+                        "policies" : [
+                            {
+                                "policyId" : "unique"
+                            },
+                            {
+                                "policyId" : "no-internal-user-conflict"
+                            },
+                            {
+                                "policyId" : "cannot-contain-characters",
+                                "params" : {
+                                    "forbiddenChars" : [
+                                        "/"
+                                    ]
+                                }
+                            },
+                            {
+                                "policyId" : "minimum-length",
+                                "params" : {
+                                    "minLength" : 1
+                                }
+                            },
+                            {
+                                "policyId" : "maximum-length",
+                                "params" : {
+                                    "maxLength" : 255
+                                }
+                            }
+                        ]
+                    },
+                    "manager" : {
+                        "type" : "relationship",
+                        "validate" : true,
+                        "reverseRelationship" : true,
+                        "reversePropertyName" : "reports",
+                        "description" : "Manager",
+                        "title" : "Manager",
+                        "viewable" : true,
+                        "searchable" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "properties" : {
+                            "_ref" : {
+                                "description" : "References a relationship from a managed object",
+                                "type" : "string"
+                            },
+                            "_refProperties" : {
+                                "description" : "Supports metadata within the relationship",
+                                "type" : "object",
+                                "title" : "Manager _refProperties",
+                                "properties" : {
+                                    "_id" : {
+                                        "description" : "_refProperties object ID",
+                                        "type" : "string"
+                                    }
+                                }
+                            }
+                        },
+                        "resourceCollection" : [
+                            {
+                                "path" : "managed/user",
+                                "label" : "User",
+                                "query" : {
+                                    "queryFilter" : "true",
+                                    "fields" : [
+                                        "userName",
+                                        "givenName",
+                                        "sn"
+                                    ]
+                                }
+                            }
+                        ],
+                        "userEditable" : false
+                    },
+                    "lastSync" : {
+                        "description" : "Last Sync timestamp",
+                        "title" : "Last Sync timestamp",
+                        "type" : "object",
+                        "scope" : "private",
+                        "viewable" : false,
+                        "searchable" : false,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "properties" : {
+                            "effectiveAssignments" : {
+                                "description" : "Effective Assignments",
+                                "title" : "Effective Assignments",
+                                "type" : "array",
+                                "items" : {
+                                    "type" : "object",
+                                    "title" : "Effective Assignments Items"
+                                }
+                            },
+                            "timestamp" : {
+                                "description" : "Timestamp",
+                                "type" : "string"
+                            }
+                        },
+                        "order" : [
+                            "effectiveAssignments",
+                            "timestamp"
+                        ],
+                        "required": []
+                    },
+                    "consentedMappings" : {
+                        "title" : "Consented Mappings",
+                        "description" : "Consented Mappings",
+                        "type" : "array",
+                        "viewable" : false,
+                        "searchable" : false,
+                        "userEditable" : true,
+                        "usageDescription" : "",
+                        "isPersonal" : false,
+                        "items" : {
+                            "type" : "array",
+                            "title" : "Consented Mappings Items",
+                            "items" : {
+                                "type" : "object",
+                                "title" : "Consented Mappings Item",
+                                "properties" : {
+                                    "mapping" : {
+                                        "title" : "Mapping",
+                                        "description" : "Mapping",
+                                        "type" : "string",
+                                        "viewable" : true,
+                                        "searchable" : true,
+                                        "userEditable" : true
+                                    },
+                                    "consentDate" : {
+                                        "title" : "Consent Date",
+                                        "description" : "Consent Date",
+                                        "type" : "string",
+                                        "viewable" : true,
+                                        "searchable" : true,
+                                        "userEditable" : true
+                                    }
+                                },
+                                "order" : [
+                                    "mapping",
+                                    "consentDate"
+                                ],
+                                "required" : [
+                                    "mapping",
+                                    "consentDate"
+                                ]
+                            }
+                        },
+                        "returnByDefault" : false,
+                        "isVirtual" : false
+                    }
+                },
+                "type" : "object",
+                "required" : [
+                    "userName",
+                    "givenName",
+                    "sn",
+                    "mail"
+                ]
+            },
+            "meta" : {
+              "property" : "_meta",
+              "resourceCollection" : "internal/usermeta",
+              "trackedProperties" : [
+                  "createDate",
+                  "lastChanged"
+              ]
+            },
+            "notifications" : {
+              "property" : "_notifications"
+            }
+        },
+        {
+            "name" : "role",
+            "onDelete" : {
+                "type" : "text/javascript",
+                "file" : "roles/onDelete-roles.js"
+            },
+            "postCreate" : {
+                "type" : "text/javascript",
+                "source" : "require('roles/postOperation-roles').manageTemporalConstraints(resourceName);"
+            },
+            "postUpdate" : {
+                "type" : "text/javascript",
+                "source" : "require('roles/postOperation-roles').manageTemporalConstraints(resourceName);"
+            },
+            "postDelete" : {
+                "type" : "text/javascript",
+                "source" : "require('roles/postOperation-roles').manageTemporalConstraints(resourceName);"
+            },
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:Role",
+                "$schema" : "http://forgerock.org/json-schema#",
+                "type" : "object",
+                "title" : "Role",
+                "icon" : "fa-check-square-o",
+                "description" : "",
+                "properties" : {
+                    "_id" : {
+                        "description" : "Role ID",
+                        "title" : "Name",
+                        "viewable" : false,
+                        "searchable" : false,
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "description" : "The role name, used for display purposes.",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "searchable" : true,
+                        "type" : "string"
+                    },
+                    "description" : {
+                        "description" : "The role description, used for display purposes.",
+                        "title" : "Description",
+                        "viewable" : true,
+                        "searchable" : true,
+                        "type" : "string"
+                    },
+                    "members" : {
+                        "description" : "Role Members",
+                        "title" : "Role Members",
+                        "viewable" : true,
+                        "type" : "array",
+                        "returnByDefault" : false,
+                        "relationshipGrantTemporalConstraintsEnforced" : true,
+                        "items" : {
+                            "type" : "relationship",
+                            "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:Role:members:items",
+                            "title" : "Role Members Items",
+                            "reverseRelationship" : true,
+                            "reversePropertyName" : "roles",
+                            "validate" : true,
+                            "properties" : {
+                                "_ref" : {
+                                    "description" : "References a relationship from a managed object",
+                                    "type" : "string"
+                                },
+                                "_refProperties" : {
+                                    "description" : "Supports metadata within the relationship",
+                                    "type" : "object",
+                                    "title" : "Role Members Items _refProperties",
+                                    "properties" : {
+                                        "_id" : {
+                                            "description" : "_refProperties object ID",
+                                            "type" : "string"
+                                        },
+                                        "_grantType" : {
+                                            "description" : "Grant Type",
+                                            "type" : "string",
+                                            "label" : "Grant Type"
+                                        }
+                                    }
+                                }
+                            },
+                            "resourceCollection" : [
+                                {
+                                    "notify" : true,
+                                    "conditionalAssociation" : true,
+                                    "path" : "managed/user",
+                                    "label" : "User",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "userName",
+                                            "givenName",
+                                            "sn"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "authzMembers" : {
+                        "description" : "Authorization Role Members",
+                        "title" : "Authorization Role Members",
+                        "viewable" : true,
+                        "type" : "array",
+                        "returnByDefault" : false,
+                        "items" : {
+                            "type" : "relationship",
+                            "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:Role:authzMembers:items",
+                            "title" : "Authorization Role Members Items",
+                            "reverseRelationship" : true,
+                            "reversePropertyName" : "authzRoles",
+                            "validate" : true,
+                            "properties" : {
+                                "_ref" : {
+                                    "description" : "References a relationship from a managed object",
+                                    "type" : "string"
+                                },
+                                "_refProperties" : {
+                                    "description" : "Supports metadata within the relationship",
+                                    "type" : "object",
+                                    "title" : "Authorization Role Members Items _refProperties",
+                                    "properties" : {
+                                        "_id" : {
+                                            "description" : "_refProperties object ID",
+                                            "type" : "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "resourceCollection" : [
+                                {
+                                    "path" : "managed/user",
+                                    "conditionalAssociation" : true,
+                                    "label" : "User",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "userName",
+                                            "givenName",
+                                            "sn"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "assignments" : {
+                        "description" : "Managed Assignments",
+                        "title" : "Managed Assignments",
+                        "viewable" : true,
+                        "returnByDefault" : false,
+                        "type" : "array",
+                        "items" : {
+                            "type" : "relationship",
+                            "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:Role:assignments:items",
+                            "title" : "Managed Assignments Items",
+                            "reverseRelationship" : true,
+                            "reversePropertyName" : "roles",
+                            "notifySelf" : true,
+                            "validate" : true,
+                            "properties" : {
+                                "_ref" : {
+                                    "description" : "References a relationship from a managed object",
+                                    "type" : "string"
+                                },
+                                "_refProperties" : {
+                                    "description" : "Supports metadata within the relationship",
+                                    "title" : "Managed Assignments Items _refProperties",
+                                    "type" : "object",
+                                    "properties" : {
+                                        "_id" : {
+                                            "description" : "_refProperties object ID",
+                                            "type" : "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "resourceCollection" : [
+                                {
+                                    "path" : "managed/assignment",
+                                    "label" : "Assignment",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            ]
+                        },
+                        "notifyRelationships" : ["members"]
+                    },
+                    "condition" : {
+                        "description" : "A conditional filter for this role",
+                        "title" : "Condition",
+                        "viewable" : false,
+                        "searchable" : false,
+                        "isConditional" : true,
+                        "type" : "string"
+                    },
+                    "temporalConstraints" : {
+                        "description" : "An array of temporal constraints for a role",
+                        "title" : "Temporal Constraints",
+                        "viewable" : false,
+                        "returnByDefault" : true,
+                        "type" : "array",
+                        "items" : {
+                            "type" : "object",
+                            "title" : "Temporal Constraints Items",
+                            "properties" : {
+                                "duration" : {
+                                    "description" : "Duration",
+                                    "type" : "string"
+                                }
+                            },
+                            "required" : [
+                                "duration"
+                            ],
+                            "order" : [
+                                "duration"
+                            ]
+                        },
+                        "notifyRelationships" : ["members"]
+                    }
+                },
+                "required" : [
+                    "name"
+                ],
+                "order" : [
+                    "_id",
+                    "name",
+                    "description",
+                    "members",
+                    "authzMembers",
+                    "assignments",
+                    "condition",
+                    "temporalConstraints"
+                ]
+            }
+        },
+        {
+            "name" : "assignment",
+            "schema" : {
+                "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:Assignment",
+                "$schema" : "http://forgerock.org/json-schema#",
+                "type" : "object",
+                "title" : "Assignment",
+                "icon" : "fa-key",
+                "description" : "A role assignment",
+                "properties" : {
+                    "_id" : {
+                        "description" : "The assignment ID",
+                        "title" : "Name",
+                        "viewable" : false,
+                        "searchable" : false,
+                        "type" : "string"
+                    },
+                    "name" : {
+                        "description" : "The assignment name, used for display purposes.",
+                        "title" : "Name",
+                        "viewable" : true,
+                        "searchable" : true,
+                        "type" : "string"
+                    },
+                    "description" : {
+                        "description" : "The assignment description, used for display purposes.",
+                        "title" : "Description",
+                        "viewable" : true,
+                        "searchable" : true,
+                        "type" : "string"
+                    },
+                    "mapping" : {
+                        "description" : "The name of the mapping this assignment applies to",
+                        "title" : "Mapping",
+                        "viewable" : true,
+                        "searchable" : true,
+                        "type" : "string",
+                        "policies" : [
+                            {
+                                "policyId" : "mapping-exists"
+                            }
+                        ]
+                    },
+                    "attributes" : {
+                        "description" : "The attributes operated on by this assignment.",
+                        "title" : "Assignment Attributes",
+                        "viewable" : true,
+                        "type" : "array",
+                        "items" : {
+                            "type" : "object",
+                            "title" : "Assignment Attributes Items",
+                            "properties" : {
+                                "assignmentOperation" : {
+                                    "description" : "Assignment operation",
+                                    "type" : "string"
+                                },
+                                "unassignmentOperation" : {
+                                    "description" : "Unassignment operation",
+                                    "type" : "string"
+                                },
+                                "name" : {
+                                    "description" : "Name",
+                                    "type" : "string"
+                                },
+                                "value" : {
+                                    "description" : "Value",
+                                    "type" : "string"
+                                }
+                            },
+                            "order" : [
+                                "assignmentOperation",
+                                "unassignmentOperation",
+                                "name",
+                                "value"
+                            ],
+                            "required": []
+                        },
+                        "notifyRelationships" : ["roles"]
+                    },
+                    "linkQualifiers" : {
+                        "description" : "Conditional link qualifiers to restrict this assignment to.",
+                        "title" : "Link Qualifiers",
+                        "viewable" : true,
+                        "type" : "array",
+                        "items" : {
+                            "type" : "string",
+                            "title" : "Link Qualifiers Items"
+                        }
+                    },
+                    "roles" : {
+                        "description" : "Managed Roles",
+                        "title" : "Managed Roles",
+                        "viewable" : true,
+                        "userEditable" : false,
+                        "type" : "array",
+                        "returnByDefault" : false,
+                        "items" : {
+                            "type" : "relationship",
+                            "id" : "urn:jsonschema:org:forgerock:openidm:managed:api:Assignment:roles:items",
+                            "title" : "Managed Roles Items",
+                            "reverseRelationship" : true,
+                            "reversePropertyName" : "assignments",
+                            "validate" : true,
+                            "properties" : {
+                                "_ref" : {
+                                    "description" : "References a relationship from a managed object",
+                                    "type" : "string"
+                                },
+                                "_refProperties" : {
+                                    "description" : "Supports metadata within the relationship",
+                                    "type" : "object",
+                                    "title" : "Managed Roles Items _refProperties",
+                                    "properties" : {
+                                        "_id" : {
+                                            "description" : "_refProperties object ID",
+                                            "type" : "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "resourceCollection" : [
+                                {
+                                    "notify" : true,
+                                    "path" : "managed/role",
+                                    "label" : "Role",
+                                    "query" : {
+                                        "queryFilter" : "true",
+                                        "fields" : [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                "required" : [
+                    "name",
+                    "description",
+                    "mapping"
+                ],
+                "order" : [
+                    "_id",
+                    "name",
+                    "description",
+                    "mapping",
+                    "attributes",
+                    "linkQualifiers",
+                    "roles"
+                ]
+            }
+        }
+    ]
+}

--- a/forgecloud/default/idm/base/conf/metrics.json
+++ b/forgecloud/default/idm/base/conf/metrics.json
@@ -1,0 +1,4 @@
+{
+    "enabled" : false,
+    "prometheusRole" : "&{openidm.prometheus.role}"
+}

--- a/forgecloud/default/idm/base/conf/notification-passwordUpdate.json
+++ b/forgecloud/default/idm/base/conf/notification-passwordUpdate.json
@@ -1,0 +1,24 @@
+{
+    "enabled" : true,
+    "path" : "managed/user/*",
+    "methods" : [
+        "update",
+        "patch"
+    ],
+    "condition" : {
+        "type" : "groovy",
+        "globals" : {
+            "propertiesToCheck" : [
+                "password"
+            ]
+        },
+        "file" : "propertiesModifiedFilter.groovy"
+    },
+    "target" : {
+        "resource" : "managed/user/{{response/_id}}"
+    },
+    "notification" : {
+        "notificationType": "info",
+        "message": "Your password has been updated."
+    }
+}

--- a/forgecloud/default/idm/base/conf/notification-profileUpdate.json
+++ b/forgecloud/default/idm/base/conf/notification-profileUpdate.json
@@ -1,0 +1,37 @@
+{
+    "enabled" : true,
+    "path" : "managed/user/*",
+    "methods" : [
+        "update",
+        "patch"
+    ],
+    "condition" : {
+        "type" : "groovy",
+        "globals" : {
+            "propertiesToCheck" : [
+                "userName",
+                "givenName",
+                "sn",
+                "mail",
+                "description",
+                "accountStatus",
+                "telephoneNumber",
+                "postalAddress",
+                "address2",
+                "city",
+                "postalCode",
+                "country",
+                "stateProvince",
+                "preferences"
+            ]
+        },
+        "file" : "propertiesModifiedFilter.groovy"
+    },
+    "target" : {
+        "resource" : "managed/user/{{response/_id}}"
+    },
+    "notification" : {
+        "notificationType" : "info",
+        "message" : "Your profile has been updated."
+    }
+}

--- a/forgecloud/default/idm/base/conf/notificationFactory.json
+++ b/forgecloud/default/idm/base/conf/notificationFactory.json
@@ -1,0 +1,9 @@
+{
+    "enabled" : true,
+    "threadPool" : {
+        "steadyPoolThreads" : 1,
+        "maxPoolThreads" : 2,
+        "threadKeepAlive" : 60,
+        "maxQueueSize" : 20000
+    }
+}

--- a/forgecloud/default/idm/base/conf/policy.json
+++ b/forgecloud/default/idm/base/conf/policy.json
@@ -1,0 +1,239 @@
+{
+    "type" : "text/javascript",
+    "file" : "policy.js",
+    "additionalFiles" : [ ],
+    "resources" : [
+        {
+            "resource" : "selfservice/registration",
+            "calculatedProperties" : {
+                "type" : "text/javascript",
+                "source" : "require('selfServicePolicies').getRegistrationProperties()"
+            }
+        },
+        {
+            "resource" : "selfservice/reset",
+            "calculatedProperties" : {
+                "type" : "text/javascript",
+                "source" : "require('selfServicePolicies').getResetProperties()"
+            }
+        },
+        {
+            "resource" : "internal/user/*",
+            "properties" : [
+                {
+                    "name" : "_id",
+                    "policies" : [
+                        {
+                            "policyId" : "cannot-contain-characters",
+                            "params" : {
+                                "forbiddenChars" : [
+                                    "/"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name" : "password",
+                    "policies" : [
+                        {
+                            "policyId" : "required"
+                        },
+                        {
+                            "policyId" : "not-empty"
+                        },
+                        {
+                            "policyId" : "minimum-length",
+                            "params" : {
+                                "minLength" : 8
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource" : "internal/role/*",
+            "properties" : [
+                {
+                    "name" : "name",
+                    "policies" : [
+                        {
+                            "policyId" : "required"
+                        },
+                        {
+                            "policyId" : "not-empty"
+                        },
+                        {
+                            "policyId" : "cannot-contain-characters",
+                            "params" : {
+                                "forbiddenChars" : [
+                                    "/*"
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name" : "temporalConstraints",
+                    "policies" : [
+                        {
+                            "policyId" : "valid-temporal-constraints"
+                        }
+                    ]
+                },
+                {
+                    "name" : "privileges",
+                    "policies" : [
+                        {
+                            "policyId" : "valid-type",
+                            "params" : {
+                                "types" : [
+                                    "array"
+                                ]
+                            }
+                        },
+                        {
+                            "policyId" : "valid-array-items",
+                            "params" : {
+                                "properties" : [
+                                    {
+                                        "name" : "name",
+                                        "policies" : [
+                                            {
+                                                "policyId" : "required"
+                                            },
+                                            {
+                                                "policyId" : "not-empty"
+                                            },
+                                            {
+                                                "policyId" : "valid-type",
+                                                "params" : {
+                                                    "types" : [
+                                                        "string"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "name" : "path",
+                                        "policies" : [
+                                            {
+                                                "policyId" : "required"
+                                            },
+                                            {
+                                                "policyId" : "not-empty"
+                                            },
+                                            {
+                                                "policyId" : "cannot-contain-characters",
+                                                "params" : {
+                                                    "forbiddenChars" : [
+                                                        "/*"
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "policyId" : "valid-privilege-path"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "name" : "accessFlags",
+                                        "policies" : [
+                                            {
+                                                "policyId" : "required"
+                                            },
+                                            {
+                                                "policyId" : "not-empty"
+                                            },
+                                            {
+                                                "policyId" : "valid-type",
+                                                "params" : {
+                                                    "types" : [
+                                                        "array"
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "policyId" : "valid-accessFlags-object"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "name" : "actions",
+                                        "policies" : [
+                                            {
+                                                "policyId" : "required"
+                                            },
+                                            {
+                                                "policyId" : "valid-type",
+                                                "params" : {
+                                                    "types" : [
+                                                        "array"
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "name" : "permissions",
+                                        "policies" : [
+                                            {
+                                                "policyId" : "required"
+                                            },
+                                            {
+                                                "policyId" : "not-empty"
+                                            },
+                                            {
+                                                "policyId" : "valid-type",
+                                                "params" : {
+                                                    "types" : [
+                                                        "array"
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "policyId" : "valid-permissions"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "name" : "filter",
+                                        "policies" : [
+                                            {
+                                                "policyId" : "valid-type",
+                                                "params" : {
+                                                    "types" : [
+                                                        "string",
+                                                        "null"
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "policyId" : "valid-query-filter"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource" : "managed/role/*",
+            "properties" : [
+                {
+                    "name" : "temporalConstraints",
+                    "policies" : [
+                        {
+                            "policyId" : "valid-temporal-constraints"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/forgecloud/default/idm/base/conf/process-access.json
+++ b/forgecloud/default/idm/base/conf/process-access.json
@@ -1,0 +1,18 @@
+{
+    "workflowAccess" : [
+        {
+            "propertiesCheck" : {
+                "property" : "_id",
+                "matches" : ".*",
+                "requiresRole" : "internal/role/openidm-authorized"
+            }
+        },
+        {
+            "propertiesCheck" : {
+                "property" : "_id",
+                "matches" : ".*",
+                "requiresRole" : "internal/role/openidm-admin"
+            }
+        }
+    ]
+}

--- a/forgecloud/default/idm/base/conf/repo.ds.json
+++ b/forgecloud/default/idm/base/conf/repo.ds.json
@@ -1,0 +1,430 @@
+{
+  "embedded": true,
+  "maxConnectionAttempts" : 5,
+  "queries": {
+    "generic": {
+      "query-all-ids": {
+        "_queryFilter": "true",
+        "_fields": "_id,_rev"
+      },
+      "credential-query": {
+        "_queryFilter": "/userName eq \"${username}\" AND /accountStatus eq \"active\""
+      },
+      "credential-internaluser-query": {
+        "_queryFilter": "/_id eq \"${username}\""
+      },
+      "get-by-field-value": {
+        "_queryFilter": "/${field} eq \"${value}\""
+      },
+      "for-userName": {
+        "_queryFilter": "/userName eq \"${uid}\""
+      },
+      "query-all": {
+        "_queryFilter": "true"
+      },
+      "links-for-firstId": {
+        "_queryFilter": "/linkType eq \"${linkType}\" AND /firstId eq \"${firstId}\""
+      },
+      "links-for-linkType": {
+        "_queryFilter": "/linkType eq \"${linkType}\""
+      },
+      "get-recons": {
+        "_queryFilter": "/entryType eq \"summary\"",
+        "_fields": "reconId,mapping,activitydate",
+        "_sortKeys": "-activitydate"
+      },
+      "get-notifications-for-user": {
+        "_queryFilter": "/receiverId eq \"${userId}\"",
+        "_sortKeys": "-createDate"
+      },
+      "query-cluster-failed-instances": {
+        "_queryFilter": "/timestamp le \"${timestamp}\" and (/state eq 1 or /state eq 2)"
+      },
+      "query-cluster-running-instances": {
+        "_queryFilter": "/state eq 1"
+      },
+      "query-cluster-instances": {
+        "_queryFilter": "true"
+      },
+      "query-cluster-events": {
+        "_queryFilter": "/instanceId eq \"${instanceId}\""
+      },
+      "find-relationships-for-resource": {
+        "_queryFilter": "(/firstResourceCollection eq \"${resourceCollection}\" and /firstResourceId eq \"${resourceId}\" and /firstPropertyName eq \"${propertyName}\") or (/secondResourceCollection eq \"${resourceCollection}\" and /secondResourceId eq \"${resourceId}\" and /secondPropertyName eq \"${propertyName}\")"
+      },
+      "find-relationship-edges": {
+        "_queryFilter": "((/firstResourceCollection eq \"${firstResourceCollection}\" and /firstResourceId eq \"${firstResourceId}\" and /firstPropertyName eq \"${firstPropertyName}\") and (/secondResourceCollection eq \"${secondResourceCollection}\" and /secondResourceId eq \"${secondResourceId}\" and /secondPropertyName eq \"${secondPropertyName}\")) or ((/firstResourceCollection eq \"${secondResourceCollection}\" and /firstResourceId eq \"${secondResourceId}\" and /firstPropertyName eq \"${secondPropertyName}\") and (/secondResourceCollection eq \"${firstResourceCollection}\" and /secondResourceId eq \"${firstResourceId}\" and /secondPropertyName eq \"${firstPropertyName}\"))"
+      }
+    },
+    "explicit": {
+      "query-all-ids": {
+        "_queryFilter": "true",
+        "_fields": "_id,_rev"
+      },
+      "credential-query": {
+        "_queryFilter": "/userName eq \"${username}\" AND /accountStatus eq \"active\""
+      },
+      "credential-internaluser-query": {
+        "_queryFilter": "/_id eq \"${username}\""
+      },
+      "links-for-firstId": {
+        "_queryFilter": "/linkType eq \"${linkType}\" AND /firstId eq \"${firstId}\""
+      },
+      "links-for-linkType": {
+        "_queryFilter": "/linkType eq \"${linkType}\""
+      },
+      "query-all": {
+        "_queryFilter": "true"
+      },
+      "for-userName": {
+        "_queryFilter": "/userName eq \"${uid}\""
+      }
+    }
+  },
+  "commands" : {
+    "delete-mapping-links" : {
+      "_queryFilter": "/linkType eq \"${mapping}\"",
+      "operation": "DELETE"
+    },
+    "delete-target-ids-for-recon" : {
+      "_queryFilter": "/reconId eq \"${reconId}\"",
+      "operation": "DELETE"
+    }
+  },
+  "rest2LdapOptions": {
+    "readOnUpdatePolicy": "controls",
+    "useSubtreeDelete": true,
+    "usePermissiveModify": true,
+    "useMvcc": true,
+    "mvccAttribute": "etag",
+    "returnNullForMissingProperties": true
+  },
+  "indices" : { },
+  "schemaProviders" : { },
+  "resourceMapping": {
+    "defaultMapping": {
+      "dnTemplate": "ou=generic,dc=openidm,dc=forgerock,dc=com"
+    },
+    "explicitMapping": {
+      "internal/user": {
+        "dnTemplate": "ou=users,ou=internal,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses": [ "uidObject", "fr-idm-internal-user" ],
+        "properties": {
+          "_id": {
+            "type": "simple", "ldapAttribute": "uid", "isRequired": true, "writability": "createOnly"
+          },
+          "password": {
+            "type": "json", "ldapAttribute": "fr-idm-password"
+          }
+        }
+      },
+      "internal/role": {
+        "dnTemplate": "ou=roles,ou=internal,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses": [ "fr-idm-internal-role" ],
+        "properties": {
+          "_id": {
+            "type": "simple", "ldapAttribute": "cn", "isRequired": true, "writability": "createOnly"
+          },
+          "name": {
+            "type": "simple", "ldapAttribute": "fr-idm-name"
+          },
+          "description": {
+            "type": "simple", "ldapAttribute": "description"
+          },
+          "temporalConstraints": {
+            "type": "json", "ldapAttribute": "fr-idm-temporal-constraints", "isMultiValued": true
+          },
+          "condition": {
+            "type": "simple", "ldapAttribute": "fr-idm-condition"
+          },
+          "privileges" : {
+            "type": "json", "ldapAttribute": "fr-idm-privilege", "isMultiValued": true
+          }
+        }
+      },
+      "link": {
+        "dnTemplate": "ou=links,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses": [ "uidObject", "fr-idm-link" ],
+        "properties": {
+          "_id": {
+            "type": "simple", "ldapAttribute": "uid", "isRequired": true, "writability": "createOnly"
+          },
+          "linkType": {
+            "type": "simple", "ldapAttribute": "fr-idm-link-type"
+          },
+          "linkQualifier": {
+            "type": "simple", "ldapAttribute": "fr-idm-link-qualifier"
+          },
+          "firstId": {
+            "type": "simple", "ldapAttribute": "fr-idm-link-firstId"
+          },
+          "secondId": {
+            "type": "simple", "ldapAttribute": "fr-idm-link-secondId"
+          }
+        }
+      },
+      "clusteredrecontargetids" : {
+        "dnTemplate": "ou=clusteredrecontargetids,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses": [ "uidObject", "fr-idm-recon-clusteredTargetIds" ],
+        "properties": {
+          "_id": {
+            "type": "simple", "ldapAttribute": "uid", "isRequired": true, "writability": "createOnly"
+          },
+          "reconId": {
+            "type": "simple", "ldapAttribute": "fr-idm-recon-id"
+          },
+          "targetIds": {
+            "type": "json", "ldapAttribute": "fr-idm-recon-targetIds"
+          }
+        }
+      },
+      "locks" : {
+        "dnTemplate": "ou=locks,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses": [ "uidObject", "fr-idm-lock" ],
+        "properties": {
+          "_id": {
+            "type": "simple", "ldapAttribute": "uid", "isRequired": true, "writability": "createOnly"
+          },
+          "nodeId": {
+            "type": "simple", "ldapAttribute": "fr-idm-lock-nodeid"
+          }
+        }
+      },
+      "sync/queue" : {
+        "dnTemplate": "ou=queue,ou=sync,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses": [ "uidObject", "fr-idm-syncqueue" ],
+        "properties": {
+          "_id": {
+            "type": "simple", "ldapAttribute": "uid", "isRequired": true, "writability": "createOnly"
+          },
+          "syncAction": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-syncaction"
+          },
+          "resourceCollection": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-resourcecollection"
+          },
+          "resourceId": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-resourceid"
+          },
+          "mapping": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-mapping"
+          },
+          "objectRev": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-objectRev"
+          },
+          "oldObject": {
+            "type": "json", "ldapAttribute": "fr-idm-syncqueue-oldobject"
+          },
+          "newObject": {
+            "type": "json", "ldapAttribute": "fr-idm-syncqueue-newobject"
+          },
+          "context": {
+            "type": "json", "ldapAttribute": "fr-idm-syncqueue-context"
+          },
+          "state": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-state"
+          },
+          "nodeId": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-nodeid"
+          },
+          "remainingRetries": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-remainingretries"
+          },
+          "createDate": {
+            "type": "simple", "ldapAttribute": "fr-idm-syncqueue-createdate"
+          }
+        }
+      },
+      "recon/assoc" : {
+        "dnTemplate" : "ou=assoc,ou=recon,dc=openidm,dc=forgerock,dc=com",
+        "namingStrategy" : {
+          "dnAttribute" : "fr-idm-reconassoc-reconid",
+          "type" : "clientDnNaming"
+        },
+        "objectClasses" : [
+          "fr-idm-reconassoc"
+        ],
+        "properties" : {
+          "_id" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-reconid",
+            "isRequired" : true
+          },
+          "mapping" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-mapping"
+          },
+          "sourceResourceCollection" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-sourceresourcecollection"
+          },
+          "targetResourceCollection" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-targetresourcecollection"
+          },
+          "isAnalysis" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-isanalysis"
+          },
+          "finishTime" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-finishtime"
+          }
+        },
+        "subResources" : {
+          "entry" : {
+            "type" : "collection",
+            "resource" : "recon-assoc-entry",
+            "namingStrategy" : {
+              "dnAttribute" : "uid",
+              "type" : "clientDnNaming"
+            }
+          }
+        }
+      },
+      "recon/assoc/entry" : {
+        "resourceName" : "recon-assoc-entry",
+        "objectClasses" : [
+          "uidObject",
+          "fr-idm-reconassocentry"
+        ],
+        "subResourceRouting" : [
+          {
+            "template" : "recon/assoc/{reconId}/entry",
+            "prefix" : "entry"
+          }
+        ],
+        "properties" : {
+          "_id" : {
+            "type" : "simple",
+            "ldapAttribute" : "uid",
+            "isRequired" : true
+          },
+          "reconId" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-reconid"
+          },
+          "linkQualifier" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-linkqualifier"
+          },
+          "status" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-status"
+          },
+          "situation" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-situation"
+          },
+          "action" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-action"
+          },
+          "phase" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-phase"
+          },
+          "sourceObjectId" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-sourceObjectId"
+          },
+          "targetObjectId" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-targetObjectId"
+          },
+          "exception" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-exception"
+          },
+          "message" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-message"
+          },
+          "messageDetail" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-messagedetail"
+          },
+          "ambiguousTargetObjectIds" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassocentry-ambiguoustargetobjectids"
+          },
+          "mapping" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-mapping"
+          },
+          "sourceResourceCollection" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-sourceresourcecollection"
+          },
+          "targetResourceCollection" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-targetresourcecollection"
+          },
+          "isAnalysis" : {
+            "type" : "simple",
+            "ldapAttribute" : "fr-idm-reconassoc-isanalysis"
+          }
+        }
+      }
+    },
+    "genericMapping": {
+      "config": {
+        "dnTemplate": "ou=config,dc=openidm,dc=forgerock,dc=com"
+      },
+      "ui/*" : {
+        "dnTemplate": "ou=ui,dc=openidm,dc=forgerock,dc=com"
+      },
+      "managed/*": {
+        "dnTemplate": "ou=managed,dc=openidm,dc=forgerock,dc=com"
+      },
+      "managed/user" : {
+        "dnTemplate" : "ou=user,ou=managed,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses" : [ "uidObject", "fr-idm-managed-user"],
+        "jsonAttribute" : "fr-idm-managed-user-json",
+        "jsonQueryEqualityMatchingRule" : "caseIgnoreJsonQueryMatchManagedUser"
+      },
+      "managed/role" : {
+        "dnTemplate" : "ou=role,ou=managed,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses" : [ "uidObject", "fr-idm-managed-role"],
+        "jsonAttribute" : "fr-idm-managed-role-json",
+        "jsonQueryEqualityMatchingRule" : "caseIgnoreJsonQueryMatchManagedRole"
+      },
+      "scheduler": {
+        "dnTemplate": "ou=scheduler,dc=openidm,dc=forgerock,dc=com"
+      },
+      "scheduler/*": {
+        "dnTemplate": "ou=scheduler,dc=openidm,dc=forgerock,dc=com"
+      },
+      "cluster/*": {
+        "dnTemplate": "ou=cluster,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses" : [ "uidObject", "fr-idm-cluster-obj" ],
+        "jsonAttribute" : "fr-idm-cluster-json",
+        "jsonQueryEqualityMatchingRule" : "caseIgnoreJsonQueryMatchClusterObject"
+      },
+      "relationships": {
+        "dnTemplate": "ou=relationships,dc=openidm,dc=forgerock,dc=com",
+        "objectClasses" : [ "uidObject", "fr-idm-relationship" ],
+        "jsonAttribute" : "fr-idm-relationship-json",
+        "jsonQueryEqualityMatchingRule" : "caseIgnoreJsonQueryMatchRelationship"
+      },
+      "updates": {
+        "dnTemplate": "ou=updates,dc=openidm,dc=forgerock,dc=com"
+      },
+      "reconprogressstate" : {
+        "dnTemplate": "ou=reconprogressstate,dc=openidm,dc=forgerock,dc=com"
+      },
+      "jsonstorage" : {
+        "dnTemplate": "ou=jsonstorage,dc=openidm,dc=forgerock,dc=com"
+      },
+      "internal/usermeta" : {
+        "dnTemplate": "ou=usermeta,ou=internal,dc=openidm,dc=forgerock,dc=com"
+      },
+      "internal/notification" : {
+        "dnTemplate": "ou=notification,ou=internal,dc=openidm,dc=forgerock,dc=com"
+      },
+      "file" : {
+        "dnTemplate": "ou=file,dc=openidm,dc=forgerock,dc=com"
+      }
+    }
+  }
+}

--- a/forgecloud/default/idm/base/conf/repo.init.json
+++ b/forgecloud/default/idm/base/conf/repo.init.json
@@ -1,0 +1,59 @@
+{
+  "insert" : {
+    "internal/role" : [
+      {
+        "id" : "openidm-admin",
+        "name" : "openidm-admin",
+        "description" : "Administrative access"
+      },
+      {
+        "id" : "openidm-authorized",
+        "name" : "openidm-authorized",
+        "description" : "Basic minimum user"
+      },
+      {
+        "id" : "openidm-reg",
+        "name" : "openidm-reg",
+        "description" : "Anonymous access"
+      },
+      {
+        "id" : "openidm-cert",
+        "name" : "openidm-cert",
+        "description" : "Authenticated via certificate"
+      },
+      {
+        "id" : "openidm-tasks-manager",
+        "name" : "openidm-tasks-manager",
+        "description" : "Allowed to reassign workflow tasks"
+      },
+      {
+        "id" : "openidm-prometheus",
+        "name" : "openidm-prometheus",
+        "description" : "Prometheus access"
+      }
+    ],
+    "internal/user" : [
+      {
+        "id" : "openidm-admin",
+        "password" : "&{openidm.admin.password}",
+        "authzRoles" : [
+          {
+            "_ref" : "internal/role/openidm-admin"
+          },
+          {
+            "_ref" : "internal/role/openidm-authorized"
+          }
+        ]
+      },
+      {
+        "id" : "anonymous",
+        "password" : "anonymous",
+        "authzRoles" : [
+          {
+            "_ref" : "internal/role/openidm-reg"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/forgecloud/default/idm/base/conf/router.json
+++ b/forgecloud/default/idm/base/conf/router.json
@@ -1,0 +1,36 @@
+{
+    "filters" : [
+        {
+            "condition" : {
+                "type" : "text/javascript",
+                "source" : "context.caller.external === true || context.current.name === 'selfservice'"
+            },
+            "onRequest" : {
+                "type" : "text/javascript",
+                "source" : "require('router-authz').testAccess()"
+            }
+        },
+        {
+            "pattern" : "^(managed|system|internal)($|(/.+))",
+            "onRequest" : {
+                "type" : "text/javascript",
+                "file" : "policyFilter.js"
+            },
+            "methods" : [
+                "create",
+                "update"
+            ]
+        },
+        {
+            "pattern" : "^(managed|internal)($|(/.+))",
+            "condition" : {
+                "type" : "text/javascript",
+                "source" : "(context.caller.external === true || context.current.name === 'selfservice') && (typeof context.privilege === 'undefined' || Object.keys(context.privilege.privileges).length === 0)"
+            },
+            "onResponse" : {
+                "type" : "text/javascript",
+                "source" : "require('relationshipFilter').filterResponse()"
+            }
+        }
+    ]
+}

--- a/forgecloud/default/idm/base/conf/scheduler.json
+++ b/forgecloud/default/idm/base/conf/scheduler.json
@@ -1,0 +1,10 @@
+{
+    "threadPool" : {
+        "threadCount" : 10
+    },
+    "scheduler" : {
+        "executePersistentSchedules" : {
+            "$bool" : "&{openidm.scheduler.execute.persistent.schedules}"
+        }
+    }
+}

--- a/forgecloud/default/idm/base/conf/script.json
+++ b/forgecloud/default/idm/base/conf/script.json
@@ -1,0 +1,38 @@
+{
+    "properties" : { },
+    "ECMAScript" : {
+        "#javascript.debug" : "&{openidm.script.javascript.debug}",
+        "javascript.optimization.level" : 9,
+        "javascript.recompile.minimumInterval" : 60000
+    },
+    "Groovy" : {
+        "#groovy.warnings" : "likely errors #othere values [none,likely,possible,paranoia]",
+        "groovy.source.encoding" : "UTF-8",
+        "#groovy.target.directory" : "&{idm.data.dir}/classes",
+        "#groovy.target.bytecode" : "1.8",
+        "groovy.classpath" : "&{idm.install.dir}/lib",
+        "#groovy.output.verbose" : false,
+        "#groovy.output.debug" : false,
+        "#groovy.errors.tolerance" : 10,
+        "#groovy.script.extension" : ".groovy",
+        "#groovy.script.base" : "#any class extends groovy.lang.Script",
+        "groovy.recompile" : true,
+        "groovy.recompile.minimumInterval" : 60000,
+        "#groovy.target.indy" : true,
+        "#groovy.disabled.global.ast.transformations" : ""
+    },
+    "sources" : {
+        "default" : {
+            "directory" : "&{idm.install.dir}/bin/defaults/script"
+        },
+        "install" : {
+            "directory" : "&{idm.install.dir}"
+        },
+        "project" : {
+            "directory" : "&{idm.instance.dir}"
+        },
+        "project-script" : {
+            "directory" : "&{idm.instance.dir}/script"
+        }
+    }
+}

--- a/forgecloud/default/idm/base/conf/secrets.json
+++ b/forgecloud/default/idm/base/conf/secrets.json
@@ -1,0 +1,64 @@
+{
+  "stores": [
+    {
+      "name": "mainKeyStore",
+      "class": "org.forgerock.openidm.secrets.config.FileBasedStore",
+      "config": {
+        "file": "&{openidm.keystore.location|&{idm.install.dir}/security/keystore.jceks}",
+        "storetype": "&{openidm.keystore.type|JCEKS}",
+        "providerName": "&{openidm.keystore.provider|SunJCE}",
+        "storePassword": "&{openidm.keystore.password|changeit}",
+        "mappings": [
+          {
+            "secretId" : "idm.default",
+            "types": [ "ENCRYPT", "DECRYPT" ],
+            "aliases": [ "&{openidm.config.crypto.alias|openidm-sym-default}" ]
+          },
+          {
+            "secretId" : "idm.config.encryption",
+            "types": [ "ENCRYPT", "DECRYPT" ],
+            "aliases": [ "&{openidm.config.crypto.alias|openidm-sym-default}" ]
+          },
+          {
+            "secretId" : "idm.password.encryption",
+            "types": [ "ENCRYPT", "DECRYPT" ],
+            "aliases": [ "&{openidm.config.crypto.alias|openidm-sym-default}" ]
+          },
+          {
+            "secretId" : "idm.jwt.session.module.encryption",
+            "types": [ "ENCRYPT", "DECRYPT" ],
+            "aliases": [ "&{openidm.https.keystore.cert.alias|openidm-localhost}" ]
+          },
+          {
+            "secretId" : "idm.jwt.session.module.signing",
+            "types": [ "SIGN", "VERIFY" ],
+            "aliases": [ "&{openidm.config.crypto.jwtsession.hmackey.alias|openidm-jwtsessionhmac-key}" ]
+          },
+          {
+            "secretId" : "idm.selfservice.encryption",
+            "types": [ "ENCRYPT", "DECRYPT" ],
+            "aliases": [ "selfservice" ]
+          },
+          {
+            "secretId" : "idm.selfservice.signing",
+            "types": [ "SIGN", "VERIFY" ],
+            "aliases": [ "&{openidm.config.crypto.selfservice.sharedkey.alias|openidm-selfservice-key}" ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "mainTrustStore",
+      "class": "org.forgerock.openidm.secrets.config.FileBasedStore",
+      "config": {
+        "file": "&{openidm.truststore.location|&{idm.install.dir}/security/truststore}",
+        "storetype": "&{openidm.truststore.type|JKS}",
+        "providerName": "&{openidm.truststore.provider|SUN}",
+        "storePassword": "&{openidm.truststore.password|changeit}",
+        "mappings": [
+        ]
+      }
+    }
+  ],
+  "populateDefaults": true
+}

--- a/forgecloud/default/idm/base/conf/selfservice.kba.json
+++ b/forgecloud/default/idm/base/conf/selfservice.kba.json
@@ -1,0 +1,15 @@
+{
+    "kbaPropertyName" : "kbaInfo",
+    "minimumAnswersToDefine": 2,
+    "minimumAnswersToVerify": 1,
+    "questions" : {
+        "1" : {
+            "en" : "What's your favorite color?",
+            "en_GB" : "What is your favourite colour?",
+            "fr" : "Quelle est votre couleur préférée?"
+        },
+        "2" : {
+            "en" : "Who was your first employer?"
+        }
+    }
+}

--- a/forgecloud/default/idm/base/conf/selfservice.propertymap.json
+++ b/forgecloud/default/idm/base/conf/selfservice.propertymap.json
@@ -1,0 +1,50 @@
+{
+  "properties" : [
+    {
+      "source" : "givenName",
+      "target" : "givenName"
+    },
+    {
+      "source" : "familyName",
+      "target" : "sn"
+    },
+    {
+      "source" : "email",
+      "target" : "mail"
+    },
+    {
+      "source" : "postalAddress",
+      "target" : "postalAddress",
+      "condition" : "/object/postalAddress  pr"
+    },
+    {
+      "source" : "addressLocality",
+      "target" : "city",
+      "condition" : "/object/addressLocality  pr"
+    },
+    {
+      "source" : "addressRegion",
+      "target" : "stateProvince",
+      "condition" : "/object/addressRegion  pr"
+    },
+    {
+      "source" : "postalCode",
+      "target" : "postalCode",
+      "condition" : "/object/postalCode  pr"
+    },
+    {
+      "source" : "country",
+      "target" : "country",
+      "condition" : "/object/country  pr"
+    },
+    {
+      "source" : "phone",
+      "target" : "telephoneNumber",
+      "condition" : "/object/phone  pr"
+    },
+    {
+      "source" : "username",
+      "target" : "userName"
+    }
+  ]
+}

--- a/forgecloud/default/idm/base/conf/servletfilter-cors.json
+++ b/forgecloud/default/idm/base/conf/servletfilter-cors.json
@@ -1,0 +1,17 @@
+{
+    "classPathURLs" : [ ],
+    "systemProperties" : { },
+    "requestAttributes" : { },
+    "scriptExtensions" : { },
+    "initParams" : {
+        "allowedOrigins" : "https://localhost:&{openidm.port.https}",
+        "allowedMethods" : "GET,POST,PUT,DELETE,PATCH",
+        "allowedHeaders" : "accept,x-openidm-password,x-openidm-nosession,x-openidm-username,content-type,origin,x-requested-with",
+        "allowCredentials" : true,
+        "chainPreflight" : false
+    },
+    "urlPatterns" : [
+        "/*"
+    ],
+    "filterClass" : "org.eclipse.jetty.servlets.CrossOriginFilter"
+}

--- a/forgecloud/default/idm/base/conf/servletfilter-payload.json
+++ b/forgecloud/default/idm/base/conf/servletfilter-payload.json
@@ -1,0 +1,13 @@
+{
+    "classPathURLs" : [ ],
+    "systemProperties" : { },
+    "requestAttributes" : { },
+    "scriptExtensions" : { },
+    "initParams" : {
+        "maxRequestSizeInMegabytes" : 5
+    },
+    "urlPatterns" : [
+        "/*"
+    ],
+    "filterClass" : "org.forgerock.openidm.jetty.LargePayloadServletFilter"
+}

--- a/forgecloud/default/idm/base/conf/system.properties
+++ b/forgecloud/default/idm/base/conf/system.properties
@@ -1,0 +1,19 @@
+java.util.logging.config.file=&{idm.instance.dir}/conf/logging.properties
+
+# Example bootstrap setting to set on command line or in this file
+
+# To disable the JSON file monitoring you need to uncomment this line
+# openidm.fileinstall.enabled=false
+
+# To disable the persisted configuration store set this property to false.
+# This will store the configurations only in memory.
+# openidm.config.repo.enabled=false
+
+# Disable the check for Quartz updates
+org.terracotta.quartz.skipUpdateCheck=true
+
+# Force Jetty to use a logger and not system out
+org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.JavaUtilLog
+
+# Enables/Disables setting of the transaction id via the transaction id http header.
+org.forgerock.http.TrustTransactionHeader=false

--- a/forgecloud/default/idm/base/conf/ui-configuration.json
+++ b/forgecloud/default/idm/base/conf/ui-configuration.json
@@ -1,0 +1,28 @@
+{
+    "configuration" : {
+        "selfRegistration" : false,
+        "passwordReset" : false,
+        "forgotUsername" : false,
+        "lang" : "en",
+        "passwordResetLink" : "",
+        "roles" : {
+            "internal/role/openidm-authorized" : "ui-user",
+            "internal/role/openidm-admin" : "ui-admin"
+        },
+        "notificationTypes" : {
+            "info" : {
+                "name" : "common.notification.types.info",
+                "iconPath" : "images/notifications/info.png"
+            },
+            "warning" : {
+                "name" : "common.notification.types.warning",
+                "iconPath" : "images/notifications/warning.png"
+            },
+            "error" : {
+                "name" : "common.notification.types.error",
+                "iconPath" : "images/notifications/error.png"
+            }
+        },
+        "defaultNotificationType" : "info"
+    }
+}

--- a/forgecloud/default/idm/base/conf/ui-dashboard.json
+++ b/forgecloud/default/idm/base/conf/ui-dashboard.json
@@ -1,0 +1,183 @@
+{
+    "dashboard" : {
+        "widgets" : [
+            {
+                "type": "Welcome",
+                "size": "large"
+            }
+        ]
+    },
+    "adminDashboards" : [
+        {
+            "name" : "Quick Start",
+            "isDefault" : true,
+            "widgets" : [
+                {
+                    "type" : "quickStart",
+                    "size" : "large",
+                    "cards" : [
+                        {
+                            "name" : "Add Connector",
+                            "icon" : "fa-database",
+                            "href" : "#connectors/add/"
+                        },
+                        {
+                            "name" : "Create Mapping",
+                            "icon" : "fa-map-marker",
+                            "href" : "#mapping/add/"
+                        },
+                        {
+                            "name" : "Manage Roles",
+                            "icon" : "fa-check-square-o",
+                            "href" : "#resource/managed/role/list/"
+                        },
+                        {
+                            "name" : "Add Device",
+                            "icon" : "fa-tablet",
+                            "href" : "#managed/add/"
+                        },
+                        {
+                            "name" : "Configure Registration",
+                            "icon" : "fa-gear",
+                            "href" : "#selfservice/userregistration/"
+                        },
+                        {
+                            "name" : "Configure Password Reset",
+                            "icon" : "fa-gear",
+                            "href" : "#selfservice/passwordreset/"
+                        },
+                        {
+                            "name" : "Manage Users",
+                            "icon" : "fa-user",
+                            "href" : "#resource/managed/user/list/"
+                        },
+                        {
+                            "name" : "Configure System Preferences",
+                            "icon" : "fa-user",
+                            "href" : "#settings/"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name" : "System Monitoring",
+            "isDefault" : false,
+            "widgets" : [
+                {
+                    "type" : "audit",
+                    "size" : "large",
+                    "minRange" : "#b0d4cd",
+                    "maxRange" : "#24423c",
+                    "legendRange" : {
+                        "week" : [
+                            10,
+                            30,
+                            90,
+                            270,
+                            810
+                        ],
+                        "month" : [
+                            500,
+                            2500,
+                            5000
+                        ],
+                        "year" : [
+                            10000,
+                            40000,
+                            100000,
+                            250000
+                        ]
+                    }
+                },
+                {
+                    "type" : "clusterStatus",
+                    "size" : "large"
+                },
+                {
+                    "type" : "systemHealthFull",
+                    "size" : "large"
+                },
+                {
+                    "type" : "lastRecon",
+                    "size" : "large",
+                    "barchart" : "false"
+                }
+            ]
+        },
+        {
+            "name" : "Resource Report",
+            "isDefault" : false,
+            "widgets" : [
+                {
+                    "type" : "counter",
+                    "size" : "x-small",
+                    "selected" : "activeUsers"
+                },
+                {
+                    "type" : "counter",
+                    "size" : "x-small",
+                    "selected" : "rolesEnabled"
+                },
+                {
+                    "type" : "counter",
+                    "size" : "x-small",
+                    "selected" : "activeConnectors"
+                },
+                {
+                    "type" : "resourceList",
+                    "size" : "large"
+                }
+            ]
+        },
+        {
+            "name" : "Business Report",
+            "isDefault" : false,
+            "widgets" : [
+                {
+                    "type" : "signIns",
+                    "size" : "x-small",
+                    "widgetTitle" : "Sign-Ins",
+                    "providers" : [
+                        "Username/Password"
+                    ],
+                    "graphType" : "fa-pie-chart"
+                },
+                {
+                    "type" : "passwordResets",
+                    "size" : "x-small",
+                    "widgetTitle" : "Password Resets",
+                    "graphType" : "fa-bar-chart"
+                },
+                {
+                    "type" : "newRegistrations",
+                    "size" : "x-small",
+                    "widgetTitle" : "New Registrations",
+                    "providers" : [
+                        "Username/Password"
+                    ],
+                    "graphType" : "fa-line-chart"
+                },
+                {
+                    "type" : "socialLogin",
+                    "size" : "x-small",
+                    "timezone" : {
+                        "negative" : true,
+                        "hours" : "07",
+                        "minutes" : "00"
+                    }
+                },
+                {
+                    "type" : "counter",
+                    "size" : "x-small",
+                    "selected" : "socialEnabled"
+                },
+                {
+                    "type" : "counter",
+                    "size" : "x-small",
+                    "selected" : "manualRegistrations"
+                }
+            ]
+        }
+    ]
+}

--- a/forgecloud/default/idm/base/conf/ui-profile.json
+++ b/forgecloud/default/idm/base/conf/ui-profile.json
@@ -1,0 +1,40 @@
+{
+  "tabs" : [
+    {
+      "name" : "personalInfoTab",
+      "view" : "org/forgerock/openidm/ui/user/profile/personalInfo/PersonalInfoTab"
+    },
+    {
+      "name" : "signInAndSecurity",
+      "view" : "org/forgerock/openidm/ui/user/profile/signInAndSecurity/SignInAndSecurityTab"
+    },
+    {
+      "name" : "preference",
+      "view" : "org/forgerock/openidm/ui/user/profile/PreferencesTab"
+    },
+    {
+      "name" : "trustedDevice",
+      "view" : "org/forgerock/openidm/ui/user/profile/TrustedDevicesTab"
+    },
+    {
+      "name" : "oauthApplication",
+      "view" : "org/forgerock/openidm/ui/user/profile/OauthApplicationsTab"
+    },
+    {
+      "name" : "privacyAndConsent",
+      "view" : "org/forgerock/openidm/ui/user/profile/PrivacyAndConsentTab"
+    },
+    {
+      "name" : "sharing",
+      "view" : "org/forgerock/openidm/ui/user/profile/uma/SharingTab"
+    },
+    {
+      "name" : "auditHistory",
+      "view" : "org/forgerock/openidm/ui/user/profile/uma/ActivityTab"
+    },
+    {
+      "name" : "accountControls",
+      "view" : "org/forgerock/openidm/ui/user/profile/accountControls/AccountControlsTab"
+    }
+  ]
+}

--- a/forgecloud/default/idm/base/conf/ui-themeconfig.json
+++ b/forgecloud/default/idm/base/conf/ui-themeconfig.json
@@ -1,0 +1,26 @@
+{
+    "icon" : "favicon.ico",
+    "path" : "",
+    "stylesheets" : [
+        "css/bootstrap-3.4.1-custom.css",
+        "css/structure.css",
+        "css/theme.css"
+    ],
+    "settings" : {
+        "logo" : {
+            "src" : "images/logo-horizontal-white.png",
+            "title" : "ForgeRock",
+            "alt" : "ForgeRock"
+        },
+        "loginLogo" : {
+            "src" : "images/login-logo-dark.png",
+            "title" : "ForgeRock",
+            "alt" : "ForgeRock",
+            "height" : "104px",
+            "width" : "210px"
+        },
+        "footer" : {
+            "mailto" : "info@forgerock.com"
+        }
+    }
+}

--- a/forgecloud/default/idm/base/conf/ui.context-admin.json
+++ b/forgecloud/default/idm/base/conf/ui.context-admin.json
@@ -1,0 +1,9 @@
+{
+    "enabled" : true,
+    "urlContextRoot" : "/admin",
+    "defaultDir" : "&{idm.install.dir}/ui/admin/default",
+    "extensionDir" : "&{idm.install.dir}/ui/admin/extension",
+    "responseHeaders" : {
+        "X-Frame-Options" : "DENY"
+    }
+}

--- a/forgecloud/default/idm/base/conf/ui.context-api.json
+++ b/forgecloud/default/idm/base/conf/ui.context-api.json
@@ -1,0 +1,6 @@
+{
+    "enabled" : true,
+    "urlContextRoot" : "/api",
+    "defaultDir" : "&{idm.install.dir}/ui/api/default",
+    "extensionDir" : "&{idm.install.dir}/ui/api/extension"
+}

--- a/forgecloud/default/idm/base/conf/ui.context-enduser.json
+++ b/forgecloud/default/idm/base/conf/ui.context-enduser.json
@@ -1,0 +1,8 @@
+{
+    "enabled" : true,
+    "urlContextRoot" : "/",
+    "defaultDir" : "&{idm.install.dir}/ui/enduser",
+    "responseHeaders" : {
+        "X-Frame-Options" : "DENY"
+    }
+}

--- a/forgecloud/default/idm/base/conf/ui.context-oauth.json
+++ b/forgecloud/default/idm/base/conf/ui.context-oauth.json
@@ -1,0 +1,6 @@
+{
+    "enabled" : true,
+    "urlContextRoot" : "/oauthReturn",
+    "defaultDir" : "&{idm.install.dir}/ui/oauth/default",
+    "extensionDir" : "&{idm.install.dir}/ui/oauth/extension"
+}

--- a/forgecloud/default/idm/base/script/access.js
+++ b/forgecloud/default/idm/base/script/access.js
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2011-2019 ForgeRock AS. All Rights Reserved
+ *
+ * Use of this code requires a commercial software license with ForgeRock AS.
+ * or with one of its affiliates. All use shall be exclusively subject
+ * to such license between the licensee and ForgeRock AS.
+ */
+// A configuration for allowed HTTP requests. Each entry in the configuration contains a pattern
+// to match against the incoming request ID and, in the event of a match, the associated roles,
+// methods, and actions that are allowed for requests on that particular pattern.
+//
+// pattern:  A pattern to match against an incoming request's resource ID
+// roles:  A comma separated list of allowed roles
+// methods:  A comma separated list of allowed methods
+// actions:  A comma separated list of allowed actions
+// customAuthz: A custom function for additional authorization logic/checks (optional)
+// excludePatterns: A comma separated list of patterns to exclude from the pattern match (optional)
+//
+// A single '*' character indicates all possible values.  With patterns ending in "/*", the "*"
+// acts as a wild card to indicate the pattern accepts all resource IDs "below" the specified
+// pattern (prefix).  For example the pattern "managed/*" would match "managed/user" or anything
+// starting with "managed/".  Note: it would not match "managed", which would need to have its
+// own entry in the config.
+
+/*jslint vars:true*/
+
+var httpAccessConfig =
+{
+    "configs" : [
+        // Anyone can read from these endpoints
+        {
+           "pattern"    : "info/*",
+           "roles"      : "*",
+           "methods"    : "read",
+           "actions"    : "*"
+        },
+        {
+           "pattern"    : "authentication",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "login,logout"
+        },
+        {
+           "pattern"    : "identityProviders",
+           "roles"      : "*",
+           "methods"    : "action",
+           "actions"    : "getAuthRedirect,handlePostAuth,getLogoutUrl"
+        },
+        {
+           "pattern"    : "identityProviders",
+           "roles"      : "internal/role/openidm-authorized",
+           "methods"    : "action",
+           "actions"    : "normalizeProfile"
+        },
+        {
+           "pattern"    : "identityProviders",
+           "roles"      : "internal/role/openidm-authorized",
+           "methods"    : "read",
+           "actions"    : "*"
+        },
+        {
+            "pattern"    : "config/ui/themeconfig",
+            "roles"      : "*",
+            "methods"    : "read",
+            "actions"    : "*"
+        },
+        {
+           "pattern"    : "info/uiconfig",
+           "roles"      : "*",
+           "methods"    : "read",
+           "actions"    : "*"
+        },
+        {
+           "pattern"    : "config/selfservice/kbaConfig",
+           "roles"      : "*",
+           "methods"    : "read",
+           "actions"    : "*",
+           "customAuthz": "checkIfAnyFeatureEnabled(['registration', 'passwordReset'])"
+        },
+        {
+            "pattern"    : "config/ui/dashboard",
+            "roles"      : "internal/role/openidm-authorized",
+            "methods"    : "read",
+            "actions"    : "*"
+        },
+        {
+            "pattern"    : "info/features",
+            "roles"      : "*",
+            "methods"    : "query",
+            "actions"    : "*"
+        },
+        {
+            "pattern"    : "privilege",
+            "roles"      : "*",
+            "methods"    : "action",
+            "actions"    : "listPrivileges"
+        },
+        {
+            "pattern"    : "privilege/*",
+            "roles"      : "*",
+            "methods"    : "read",
+            "actions"    : "*"
+        },
+
+        // externally-visible Self-Service endpoints
+        {
+           "pattern"    : "selfservice/registration",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "submitRequirements",
+           "customAuthz" : "checkIfAnyFeatureEnabled('registration')"
+        },
+
+        {
+           "pattern"    : "selfservice/socialUserClaim",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "submitRequirements",
+           "customAuthz" : "checkIfAnyFeatureEnabled('registration')"
+        },
+
+        {
+           "pattern"    : "selfservice/reset",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "submitRequirements",
+           "customAuthz" : "checkIfAnyFeatureEnabled('passwordReset')"
+        },
+
+        {
+           "pattern"    : "selfservice/username",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "submitRequirements",
+           "customAuthz" : "checkIfAnyFeatureEnabled('retrieveUsername')"
+        },
+        {
+           "pattern"    : "selfservice/profile",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "submitRequirements"
+        },
+        {
+           "pattern"    : "selfservice/termsAndConditions",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "submitRequirements"
+        },
+        {
+           "pattern"    : "selfservice/kbaUpdate",
+           "roles"      : "*",
+           "methods"    : "read,action",
+           "actions"    : "submitRequirements"
+        },
+
+        // self-service is allowed to call the policy service to validate any route
+        {
+            "pattern"   : "policy/*",
+            "roles"     : "*",
+            "methods"   : "action",
+            "actions"   : "validateObject",
+            "customAuthz" : "context.current.name === 'selfservice'"
+        },
+
+        // anonymous users are allowed to evaluate policy only via the selfservice endpoints
+        {
+            "pattern"   : "policy/selfservice/registration",
+            "roles"     : "*",
+            "methods"   : "action,read",
+            "actions"   : "validateObject",
+            "customAuthz" : "checkIfAnyFeatureEnabled('registration')"
+        },
+
+        {
+            "pattern"   : "policy/selfservice/reset",
+            "roles"     : "*",
+            "methods"   : "action,read",
+            "actions"   : "validateObject",
+            "customAuthz" : "checkIfAnyFeatureEnabled('passwordReset')"
+        },
+
+        {
+           "pattern"    : "selfservice/kba",
+           "roles"      : "internal/role/openidm-authorized",
+           "methods"    : "read",
+           "actions"    : "*",
+           "customAuthz" : "checkIfAnyFeatureEnabled('kba')"
+        },
+
+        // rules governing requests originating from forgerock-selfservice
+        {
+            "pattern"   : "managed/user",
+            "roles"     : "internal/role/openidm-reg",
+            "methods"   : "create",
+            "actions"   : "*",
+            "customAuthz" : "checkIfAnyFeatureEnabled('registration') && isSelfServiceRequest() && onlyEditableManagedObjectProperties('user', [])"
+        },
+        {
+            "pattern"   : "managed/user",
+            "roles"     : "*",
+            "methods"   : "query",
+            "actions"   : "*",
+            "customAuthz" : "checkIfAnyFeatureEnabled(['registration', 'retrieveUsername', 'passwordReset']) && isSelfServiceRequest()"
+        },
+        {
+            "pattern"   : "managed/user/*",
+            "roles"     : "*",
+            "methods"   : "read",
+            "actions"   : "*",
+            "customAuthz" : "checkIfAnyFeatureEnabled(['retrieveUsername', 'passwordReset']) && isSelfServiceRequest()"
+        },
+        {
+            "pattern"   : "managed/user/*",
+            "roles"     : "*",
+            "methods"   : "patch,action",
+            "actions"   : "patch",
+            "customAuthz" : "(checkIfAnyFeatureEnabled(['registration', 'passwordReset']) || checkIfProgressiveProfileIsEnabled()) && isSelfServiceRequest() && onlyEditableManagedObjectProperties('user', [])"
+        },
+        {
+            "pattern"   : "external/email",
+            "roles"     : "*",
+            "methods"   : "action",
+            "actions"   : "send",
+            "customAuthz" : "checkIfAnyFeatureEnabled(['registration', 'retrieveUsername', 'passwordReset']) && isSelfServiceRequest()"
+        },
+
+        // Schema service that provides sanitized schema data needed to support the UI
+        {
+            "pattern"    : "schema/*",
+            "roles"      : "internal/role/openidm-authorized",
+            "methods"    : "read",
+            "actions"    : "*"
+        },
+
+        // Consent service that provides end-user functions related to Privacy & Consent
+        {
+            "pattern"    : "consent",
+            "roles"      : "internal/role/openidm-authorized",
+            "methods"    : "action,query",
+            "actions"    : "*"
+        },
+
+        // openidm-admin can request nearly anything (except query expressions on repo endpoints)
+        {
+            "pattern"   : "*",
+            "roles"     : "internal/role/openidm-admin",
+            "methods"   : "*", // default to all methods allowed
+            "actions"   : "*", // default to all actions allowed
+            "customAuthz" : "disallowQueryExpression()",
+            "excludePatterns": "repo,repo/*"
+        },
+        // additional rules for openidm-admin that selectively enable certain parts of system/
+        {
+            "pattern"   : "system/*",
+            "roles"     : "internal/role/openidm-admin",
+            "methods"   : "create,read,update,delete,patch,query", // restrictions on 'action'
+            "actions"   : "",
+            "customAuthz" : "disallowQueryExpression()"
+        },
+        // Allow access to custom scripted endpoints
+        {
+            "pattern"   : "system/*",
+            "roles"     : "internal/role/openidm-admin",
+            "methods"   : "script",
+            "actions"   : "*"
+        },
+        // Note that these actions are available directly on system as well
+        {
+            "pattern"   : "system/*",
+            "roles"     : "internal/role/openidm-admin",
+            "methods"   : "action",
+            "actions"   : "test,testConfig,createconfiguration,liveSync,authenticate"
+        },
+        // Disallow command action on repo
+        {
+            "pattern"   : "repo",
+            "roles"     : "internal/role/openidm-admin",
+            "methods"   : "*", // default to all methods allowed
+            "actions"   : "*", // default to all actions allowed
+            "customAuthz" : "disallowCommandAction()"
+        },
+        {
+            "pattern"   : "repo/*",
+            "roles"     : "internal/role/openidm-admin",
+            "methods"   : "*", // default to all methods allowed
+            "actions"   : "*", // default to all actions allowed
+            "customAuthz" : "disallowCommandAction()"
+        },
+        //allow the ability to delete links for a specific mapping
+        {
+            "pattern"   : "repo/link",
+            "roles"     : "internal/role/openidm-admin",
+            "methods"   : "action",
+            "actions"   : "command",
+            "customAuthz" : "request.additionalParameters.commandId === 'delete-mapping-links'"
+        },
+
+        // Additional checks for authenticated users
+        {
+            "pattern"   : "policy/*",
+            "roles"     : "internal/role/openidm-authorized", // openidm-authorized is logged-in users
+            "methods"   : "read,action",
+            "actions"   : "*"
+        },
+        {
+            "pattern"   : "config/ui/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read",
+            "actions"   : "*"
+        },
+        {
+            "pattern"   : "authentication",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "action",
+            "actions"   : "reauthenticate"
+        },
+
+        // This rule is primarily controlled by the ownDataOnly function - that will only allow
+        // access to the endpoint from which the user originates
+        // (For example a managed/user with the _id of bob will only be able to access managed/user/bob)
+
+        {
+            "pattern"   : "*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read,action,delete",
+            "actions"   : "bind,unbind",
+            "customAuthz" : "ownDataOnly()"
+        },
+        {
+            "pattern"   : "*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "update,patch,action",
+            "actions"   : "patch",
+            "customAuthz" : "ownDataOnly() && onlyEditableManagedObjectProperties('user', []) && reauthIfProtectedAttributeChange()"
+        },
+        {
+            "pattern"   : "selfservice/user/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "patch,action",
+            "actions"   : "patch",
+            "customAuthz" : "(request.resourcePath === 'selfservice/user/' + context.security.authorization.id) && onlyEditableManagedObjectProperties('user', [])"
+        },
+
+
+        // Workflow-related endpoints for authorized users
+
+        {
+            "pattern"   : "endpoint/getprocessesforuser",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read",
+            "actions"   : "*"
+        },
+        {
+            "pattern"   : "endpoint/gettasksview",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "query",
+            "actions"   : "*"
+        },
+        {
+            "pattern"   : "workflow/taskinstance/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "action",
+            "actions"   : "complete",
+            "customAuthz" : "isMyTask()"
+        },
+        {
+            "pattern"   : "workflow/taskinstance/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read,update",
+            "actions"   : "*",
+            "customAuthz" : "canUpdateTask()"
+        },
+        {
+            "pattern"   : "workflow/processinstance",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "create",
+            "actions"   : "*",
+            "customAuthz": "isAllowedToStartProcess()"
+        },
+        {
+            "pattern"   : "workflow/processdefinition/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "*",
+            "actions"   : "read",
+            "customAuthz": "isOneOfMyWorkflows()"
+        },
+        // Clients authenticated via SSL mutual authentication
+        {
+            "pattern"   : "managed/user",
+            "roles"     : "internal/role/openidm-cert",
+            "methods"   : "patch,action",
+            "actions"   : "patch",
+            "customAuthz" : "isQueryOneOf({'managed/user': ['for-userName']}) && restrictPatchToFields(['password'])"
+        },
+        // Grant users access to their own user metadata
+        {
+            "pattern"   : "internal/usermeta/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read",
+            "actions"   : "*",
+            "customAuthz" : "ownRelationship()"
+        },
+        // Grant users access to their own notifications
+        {
+            "pattern"   : "internal/notification/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read,delete",
+            "actions"   : "*",
+            "customAuthz" : "ownRelationship()"
+        },
+        {
+            "pattern"   : "managed/user/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read,query",
+            "actions"   : "*",
+            "customAuthz" : "ownRelationshipCollection(['idps','_meta','_notifications'])"
+        },
+        {
+            "pattern"   : "notification",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "action",
+            "actions"   : "deleteNotificationsForTarget",
+            "customAuthz" : "request.additionalParameters.target === (context.security.authorization.component + '/' + context.security.authorization.id)"
+        },
+        {
+            "pattern"   : "managed/*",
+            "roles"     : "internal/role/openidm-authorized",
+            "methods"   : "read",
+            "actions"   : "*",
+            "customAuthz" : "ownIDP()"
+        }
+    ]
+};
+
+// Additional custom authorization functions go here

--- a/forgecloud/default/idm/base/script/readme.txt
+++ b/forgecloud/default/idm/base/script/readme.txt
@@ -1,0 +1,4 @@
+All customized JavaScript files for the configuration should go into this directory.
+
+Default copies are found under bin/default/script - place them here and update the script references in the
+appropriate conf file rather than modifying the bin/default/script copy.

--- a/forgecloud/default/idm/conf/jetty.xml
+++ b/forgecloud/default/idm/conf/jetty.xml
@@ -286,12 +286,12 @@
     </Call>
 
     <!-- Fallback error handler, that returns minimal information, for errors that cannot be handled by OpenIDM -->
-    <Call name="addBean">
-        <Arg>
-            <New class="org.forgerock.openidm.jetty.JettyErrorHandler">
-                <Set name="server"><Ref refid="Server" /></Set>
-            </New>
-        </Arg>
-    </Call>
+    <!--<Call name="addBean">-->
+        <!--<Arg>-->
+            <!--<New class="org.forgerock.openidm.jetty.JettyErrorHandler">-->
+                <!--<Set name="server"><Ref refid="Server" /></Set>-->
+            <!--</New>-->
+        <!--</Arg>-->
+    <!--</Call>-->
 
 </Configure>

--- a/forgecloud/default/idm/conf/notification-passwordUpdate.json
+++ b/forgecloud/default/idm/conf/notification-passwordUpdate.json
@@ -6,8 +6,13 @@
         "patch"
     ],
     "condition" : {
-        "type" : "text/javascript",
-        "source" : "(method === 'update' && content.password !== undefined) || (method === 'patch' && patchOperations.filter(function(op){ return op.field === '/password' } ).length > 0)"
+        "type" : "groovy",
+        "globals" : {
+            "propertiesToCheck" : [
+                "password"
+            ]
+        },
+        "file" : "propertiesModifiedFilter.groovy"
     },
     "target" : {
         "resource" : "managed/user/{{response/_id}}"

--- a/forgecloud/default/idm/conf/notification-profileUpdate.json
+++ b/forgecloud/default/idm/conf/notification-profileUpdate.json
@@ -6,7 +6,7 @@
         "patch"
     ],
     "condition" : {
-        "type" : "text/javascript",
+        "type" : "groovy",
         "globals" : {
             "propertiesToCheck" : [
                 "userName",
@@ -25,7 +25,7 @@
                 "preferences"
             ]
         },
-        "file" : "propertiesModifiedFilter.js"
+        "file" : "propertiesModifiedFilter.groovy"
     },
     "target" : {
         "resource" : "managed/user/{{response/_id}}"

--- a/forgecloud/default/idm/conf/repo.ds.json
+++ b/forgecloud/default/idm/conf/repo.ds.json
@@ -68,6 +68,9 @@
             "query-cluster-failed-instances": {
                 "_queryFilter": "/timestamp le ${timestamp} and (/state eq \"1\" or /state eq \"2\")"
             },
+            "query-cluster-running-instances": {
+                "_queryFilter": "/state eq 1"
+            },
             "query-cluster-instances": {
                 "_queryFilter": "true"
             },
@@ -118,10 +121,11 @@
     },
     "rest2LdapOptions": {
         "readOnUpdatePolicy": "controls",
-        "useSubtreeDelete": false,
+        "useSubtreeDelete": true,
         "usePermissiveModify": true,
         "useMvcc": true,
-        "mvccAttribute": "etag"
+        "mvccAttribute": "etag",
+        "returnNullForMissingProperties": true
     },
     "resourceMapping": {
         "defaultMapping": {

--- a/forgecloud/default/idm/conf/ui-themeconfig.json
+++ b/forgecloud/default/idm/conf/ui-themeconfig.json
@@ -2,7 +2,7 @@
     "icon" : "favicon.ico",
     "path" : "",
     "stylesheets" : [
-        "css/bootstrap-3.3.7-custom.css",
+        "css/bootstrap-3.4.1-custom.css",
         "css/structure.css",
         "css/theme.css"
     ],

--- a/scripts/export_default_idm_base_config.sh
+++ b/scripts/export_default_idm_base_config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+###
+# This script extracts the default conf and script files from the IDM Docker image
+
+###
+# Constants
+
+SCRIPT_DIR=$(dirname $0)
+GIT_REPO_ROOT=$(cd "${SCRIPT_DIR}/.."; pwd)
+IDM_EXPORT_DIR=${GIT_REPO_ROOT}/forgecloud/default/idm/base
+IDM_DOCKER_IMAGE=$(cat ${GIT_REPO_ROOT}/forgecloud/default/idm/Dockerfile | grep "FROM " | cut -d ' ' -f 2)
+
+###
+# Extract files from IDM image by running a temporary container
+
+echo -n "Extracting default IDM config for ${IDM_DOCKER_IMAGE} to ${IDM_EXPORT_DIR}..."
+
+IDM_CONTAINER=$(docker create ${IDM_DOCKER_IMAGE})
+rm -rf ${IDM_EXPORT_DIR}/conf
+rm -rf ${IDM_EXPORT_DIR}/script
+docker cp ${IDM_CONTAINER}:/opt/openidm/conf ${IDM_EXPORT_DIR}
+docker cp ${IDM_CONTAINER}:/opt/openidm/script ${IDM_EXPORT_DIR}
+1>/dev/null docker rm -v ${IDM_CONTAINER} # redirecting stdout to suppress container id output
+
+echo " done"

--- a/scripts/upgrade_identity_stack.sh
+++ b/scripts/upgrade_identity_stack.sh
@@ -13,8 +13,7 @@ GIT_REPO_ROOT=$(cd "${GIT_REPO_ROOT}"; pwd)
 # forgeops branch to use
 #  Commits to forgeops master should only be permitted when PIT 1 tests pass
 #  Commits to forgeops stable should only be permitted when PIT 2 tests pass
-#  Currently tracking master as PIT 2 tests are still being finalised
-FORGEOPS_BRANCH=master
+FORGEOPS_BRANCH=stable
 
 function print {
   echo -n -e "\e[33m${1}\e[0m"

--- a/scripts/upgrade_identity_stack.sh
+++ b/scripts/upgrade_identity_stack.sh
@@ -115,6 +115,14 @@ update_dockerfile "idm" ${GIT_REPO_ROOT}/forgecloud/default/idm/Dockerfile ${IDM
 
 println "done"
 
+###
+# Capture default config from Docker images
+
+${GIT_REPO_ROOT}/scripts/export_default_idm_base_config.sh
+
+###
+# Print out summary
+
 cat << EOF
 
 Please commit these changes to a branch and push to GitHub.


### PR DESCRIPTION
Script updates:

- Updates the upgrade identity stack script to pull in updates from the ForgeOps stable branch rather than ForgeOps master as PIT 2 test & promotion automation is now in place.
- Introduces a new script for extracting the IDM default config files to this Git repo (for reference and comparison as we move from one IDM binary to the next) - I'd be happy to pull out this change or move it to a separate PR if reviewers prefer

Updates from running the scripts:

- The updated script has been run in order to pull in the latest Identity Stack Docker images and forgeops Helm charts which have passed PIT 2 testing.
- IDM's default config has been extracted from the IDM Docker image and saved to this Git repo

Manual updates:

- Adjustments to IDM config to fix a CrashLoopBackoff